### PR TITLE
Add tabbed UI with language and theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Projet ESP-IDF pour la gestion complète d'un élevage de reptiles. Ce dépôt f
 - `main/` : point d'entrée de l'application.
 - `components/` : modules fonctionnels (base de données, UI, authentification,
   gestion des animaux et des terrariums, etc.).
-- `docs/` : documentation légale et guides d'utilisation.
+- `docs/` : documentation légale et guides d'utilisation (voir `docs/UI_USAGE.md` pour l'interface).
 
 ## Compilation
 1. Installer l'[ESP-IDF](https://docs.espressif.com/).

--- a/components/ui/ui.c
+++ b/components/ui/ui.c
@@ -1,11 +1,85 @@
 #include "ui.h"
-#include "lvgl.h"
 #include "esp_log.h"
 
 static const char *TAG = "ui";
 
-void ui_init(void)
+static ui_language_t current_lang = UI_LANG_EN;
+static ui_theme_t current_theme = UI_THEME_LIGHT;
+
+static const char *translations[UI_LANG_COUNT][TXT_COUNT] = {
+    [UI_LANG_EN] = {
+        [TXT_ANIMALS] = "Animals",
+        [TXT_TERRARIUMS] = "Terrariums",
+        [TXT_SETTINGS] = "Settings",
+    },
+    [UI_LANG_FR] = {
+        [TXT_ANIMALS] = "Animaux",
+        [TXT_TERRARIUMS] = "Terrariums",
+        [TXT_SETTINGS] = "Param\xC3\xA8tres",
+    }
+};
+
+static lv_obj_t *tabview;
+
+const char *ui_get_text(ui_text_id_t id)
 {
+    if (id >= TXT_COUNT)
+        return "";
+    return translations[current_lang][id];
+}
+
+void ui_set_language(ui_language_t lang)
+{
+    if (lang >= UI_LANG_COUNT)
+        return;
+    current_lang = lang;
+    if (tabview) {
+        lv_tabview_set_tab_name(tabview, 0, ui_get_text(TXT_ANIMALS));
+        lv_tabview_set_tab_name(tabview, 1, ui_get_text(TXT_TERRARIUMS));
+        lv_tabview_set_tab_name(tabview, 2, ui_get_text(TXT_SETTINGS));
+    }
+}
+
+static void apply_theme(void)
+{
+    lv_theme_t *th = lv_theme_default_init(NULL,
+                                           lv_palette_main(LV_PALETTE_BLUE),
+                                           lv_palette_main(LV_PALETTE_RED),
+                                           current_theme == UI_THEME_DARK,
+                                           LV_FONT_DEFAULT);
+    lv_disp_set_theme(NULL, th);
+}
+
+void ui_set_theme(ui_theme_t theme)
+{
+    if (theme >= UI_THEME_COUNT)
+        return;
+    current_theme = theme;
+    apply_theme();
+}
+
+void ui_init(ui_language_t lang, ui_theme_t theme)
+{
+    current_lang = lang;
+    current_theme = theme;
+
     ESP_LOGI(TAG, "Initialisation de l'interface LVGL");
-    // TODO: créer les écrans, onglets et la navigation
+
+    apply_theme();
+
+    tabview = lv_tabview_create(lv_scr_act(), LV_DIR_TOP, 40);
+    lv_obj_set_size(tabview, 800, 480);
+
+    lv_obj_t *tab1 = lv_tabview_add_tab(tabview, ui_get_text(TXT_ANIMALS));
+    lv_obj_t *tab2 = lv_tabview_add_tab(tabview, ui_get_text(TXT_TERRARIUMS));
+    lv_obj_t *tab3 = lv_tabview_add_tab(tabview, ui_get_text(TXT_SETTINGS));
+
+    lv_label_create(tab1);
+    lv_label_set_text(lv_obj_get_child(tab1, 0), ui_get_text(TXT_ANIMALS));
+
+    lv_label_create(tab2);
+    lv_label_set_text(lv_obj_get_child(tab2, 0), ui_get_text(TXT_TERRARIUMS));
+
+    lv_label_create(tab3);
+    lv_label_set_text(lv_obj_get_child(tab3, 0), ui_get_text(TXT_SETTINGS));
 }

--- a/components/ui/ui.h
+++ b/components/ui/ui.h
@@ -1,9 +1,54 @@
 #ifndef UI_H
 #define UI_H
 
+#include "lvgl.h"
+
 /**
- * \brief Initialise l'interface graphique.
+ * \brief Langues supportées.
  */
-void ui_init(void);
+typedef enum {
+    UI_LANG_EN, /**< Anglais */
+    UI_LANG_FR, /**< Français */
+    UI_LANG_COUNT
+} ui_language_t;
+
+/**
+ * \brief Thèmes disponibles.
+ */
+typedef enum {
+    UI_THEME_LIGHT, /**< Mode clair */
+    UI_THEME_DARK,  /**< Mode sombre */
+    UI_THEME_COUNT
+} ui_theme_t;
+
+/**
+ * \brief Identifiants de texte.
+ */
+typedef enum {
+    TXT_ANIMALS,
+    TXT_TERRARIUMS,
+    TXT_SETTINGS,
+    TXT_COUNT
+} ui_text_id_t;
+
+/**
+ * \brief Initialise l'interface graphique avec langue et thème.
+ */
+void ui_init(ui_language_t lang, ui_theme_t theme);
+
+/**
+ * \brief Change la langue de l'interface.
+ */
+void ui_set_language(ui_language_t lang);
+
+/**
+ * \brief Change le thème (clair/sombre).
+ */
+void ui_set_theme(ui_theme_t theme);
+
+/**
+ * \brief Récupère le texte traduit.
+ */
+const char *ui_get_text(ui_text_id_t id);
 
 #endif // UI_H

--- a/docs/UI_USAGE.md
+++ b/docs/UI_USAGE.md
@@ -1,0 +1,21 @@
+# Utilisation de l'interface graphique
+
+Cette application utilise LVGL pour afficher une interface en onglets adaptée aux écrans 800x480.
+
+## Initialisation
+
+```c
+ui_init(UI_LANG_EN, UI_THEME_LIGHT);
+```
+
+- **Langue** : `UI_LANG_EN` pour l'anglais ou `UI_LANG_FR` pour le français.
+- **Thème** : `UI_THEME_LIGHT` ou `UI_THEME_DARK` pour le mode clair ou sombre.
+
+## Changement de langue et de thème
+
+```c
+ui_set_language(UI_LANG_FR);
+ui_set_theme(UI_THEME_DARK);
+```
+
+Les textes des onglets sont mis à jour automatiquement selon la langue sélectionnée.

--- a/main/main.c
+++ b/main/main.c
@@ -21,7 +21,7 @@ void app_main(void)
 
     // Initialisation de LVGL et de l'interface
     lv_init();
-    ui_init();
+    ui_init(UI_LANG_EN, UI_THEME_LIGHT);
 
     // Initialisation de la base de données
     db_init();


### PR DESCRIPTION
## Summary
- implement LVGL tabbed interface for 800x480 displays
- add dark/light themes and two-language translations
- update main to pass language and theme
- document UI usage

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f16554d008323a01ef2ef80e3da27