### PR TITLE
Add PDF generation templates for legal forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Projet ESP-IDF pour la gestion complète d'un élevage de reptiles. Ce dépôt f
 
 ## Structure
 - `main/` : point d'entrée de l'application.
-- `components/` : modules fonctionnels (base de données, UI, authentification,
-  gestion des animaux et des terrariums, etc.).
+ - `components/` : modules fonctionnels (base de données, UI, authentification,
+   gestion des animaux, des terrariums et génération de documents légaux).
 - `docs/` : documentation légale et guides d'utilisation (voir `docs/UI_USAGE.md` pour l'interface).
 
 ## Compilation

--- a/components/legal/CMakeLists.txt
+++ b/components/legal/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "legal.c"
+idf_component_register(SRCS "legal.c" "legal_templates.c"
                        INCLUDE_DIRS ".")

--- a/components/legal/legal.c
+++ b/components/legal/legal.c
@@ -1,10 +1,94 @@
 #include "legal.h"
+#include "legal_templates.h"
 #include "esp_log.h"
+#include <stdio.h>
+#include <string.h>
 
 static const char *TAG = "legal";
 
-void legal_generate_all(void)
+static bool write_basic_pdf(const char *path, const char *content)
 {
-    ESP_LOGI(TAG, "Génération des documents légaux");
-    // TODO: implémenter génération CERFA, I-FAP, CITES, etc.
+    if (!path || !content)
+        return false;
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        ESP_LOGE(TAG, "Impossible d'ouvrir %s", path);
+        return false;
+    }
+
+    int off1, off2, off3, off4;
+    fprintf(f, "%%PDF-1.4\n");
+    off1 = ftell(f);
+    fprintf(f, "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    off2 = ftell(f);
+    fprintf(f, "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    off3 = ftell(f);
+    fprintf(f, "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R >>\nendobj\n");
+    off4 = ftell(f);
+    fprintf(f, "4 0 obj\n<< /Length %zu >>\nstream\n%s\nendstream\nendobj\n", strlen(content), content);
+    int xref = ftell(f);
+    fprintf(f, "xref\n0 5\n");
+    fprintf(f, "0000000000 65535 f \n");
+    fprintf(f, "%010d 00000 n \n", off1);
+    fprintf(f, "%010d 00000 n \n", off2);
+    fprintf(f, "%010d 00000 n \n", off3);
+    fprintf(f, "%010d 00000 n \n", off4);
+    fprintf(f, "trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n%d\n%%EOF\n", xref);
+    fclose(f);
+    ESP_LOGI(TAG, "PDF genere: %s", path);
+    return true;
+}
+
+bool legal_generate_cerfa(const char *path, const Reptile *r)
+{
+    if (!r)
+        return false;
+    char buffer[256];
+    snprintf(buffer, sizeof(buffer), cerfa_template, r->name, r->species, r->sex, r->birth_date);
+    return write_basic_pdf(path, buffer);
+}
+
+bool legal_generate_ifap(const char *path, const Reptile *r)
+{
+    if (!r)
+        return false;
+    char buffer[256];
+    snprintf(buffer, sizeof(buffer), ifap_template, r->name, r->species, r->id);
+    return write_basic_pdf(path, buffer);
+}
+
+bool legal_generate_cites(const char *path, const Reptile *r)
+{
+    if (!r)
+        return false;
+    char buffer[256];
+    snprintf(buffer, sizeof(buffer), cites_template, r->name, r->species);
+    return write_basic_pdf(path, buffer);
+}
+
+bool legal_generate_invoice(const char *path, const Reptile *r)
+{
+    if (!r)
+        return false;
+    char buffer[256];
+    snprintf(buffer, sizeof(buffer), invoice_template, r->name, r->species);
+    return write_basic_pdf(path, buffer);
+}
+
+void legal_generate_all(const char *dir, const Reptile *r)
+{
+    if (!dir || !r)
+        return;
+    char path[128];
+    snprintf(path, sizeof(path), "%s/cerfa.pdf", dir);
+    legal_generate_cerfa(path, r);
+
+    snprintf(path, sizeof(path), "%s/ifap.pdf", dir);
+    legal_generate_ifap(path, r);
+
+    snprintf(path, sizeof(path), "%s/cites.pdf", dir);
+    legal_generate_cites(path, r);
+
+    snprintf(path, sizeof(path), "%s/invoice.pdf", dir);
+    legal_generate_invoice(path, r);
 }

--- a/components/legal/legal.h
+++ b/components/legal/legal.h
@@ -1,9 +1,14 @@
 #ifndef LEGAL_H
 #define LEGAL_H
 
-/**
- * \brief Génère les documents légaux requis pour une opération.
- */
-void legal_generate_all(void);
+#include <stdbool.h>
+#include "animals.h"
+
+bool legal_generate_cerfa(const char *path, const Reptile *r);
+bool legal_generate_ifap(const char *path, const Reptile *r);
+bool legal_generate_cites(const char *path, const Reptile *r);
+bool legal_generate_invoice(const char *path, const Reptile *r);
+
+void legal_generate_all(const char *dir, const Reptile *r);
 
 #endif // LEGAL_H

--- a/components/legal/legal_templates.c
+++ b/components/legal/legal_templates.c
@@ -1,0 +1,24 @@
+#include "legal_templates.h"
+
+const char cerfa_template[] =
+    "CERFA Formulaire\n"
+    "Nom: %s\n"
+    "Espece: %s\n"
+    "Sexe: %s\n"
+    "Date de naissance: %s\n";
+
+const char ifap_template[] =
+    "I-FAP Declaration\n"
+    "Nom: %s\n"
+    "Espece: %s\n"
+    "Identifiant: %d\n";
+
+const char cites_template[] =
+    "CITES Document\n"
+    "Nom: %s\n"
+    "Espece: %s\n";
+
+const char invoice_template[] =
+    "Facture\n"
+    "Animal: %s\n"
+    "Espece: %s\n";

--- a/components/legal/legal_templates.h
+++ b/components/legal/legal_templates.h
@@ -1,0 +1,9 @@
+#ifndef LEGAL_TEMPLATES_H
+#define LEGAL_TEMPLATES_H
+
+extern const char cerfa_template[];
+extern const char ifap_template[];
+extern const char cites_template[];
+extern const char invoice_template[];
+
+#endif // LEGAL_TEMPLATES_H

--- a/docs/NOTICE.md
+++ b/docs/NOTICE.md
@@ -1,2 +1,3 @@
 Ce projet contient des informations générales sur la gestion d'un élevage de reptiles.
 Il appartient à l'utilisateur de s'assurer de la conformité avec la réglementation en vigueur (France, Europe, international).
+Les modèles de formulaires inclus sont simplifiés et fournis à titre indicatif. Ils doivent être vérifiés et adaptés pour garantir leur validité juridique.


### PR DESCRIPTION
## Summary
- implement basic PDF generation in `components/legal`
- provide CERFA, I-FAP, CITES and invoice templates
- update README and NOTICE with notes about legal templates

## Testing
- `cmake --version`
- `cmake -S . -B build` *(fails: IDF not configured)*

------
https://chatgpt.com/codex/tasks/task_e_685f188118488323aed2e4bcc2bd9845