### PR TITLE
Implement secure auth and storage encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Projet ESP-IDF pour la gestion complète d'un élevage de reptiles. Ce dépôt f
 - `main/` : point d'entrée de l'application.
  - `components/` : modules fonctionnels (base de données, UI, authentification,
    gestion des animaux, des terrariums et génération de documents légaux).
+   Les mots de passe sont hachés en SHA‑256 et les fichiers exportés sont chiffrés.
 - `docs/` : documentation légale et guides d'utilisation (voir `docs/UI_USAGE.md` pour l'interface).
 
 ## Compilation

--- a/components/auth/CMakeLists.txt
+++ b/components/auth/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "auth.c"
-                       INCLUDE_DIRS ".")
+                       INCLUDE_DIRS "."
+                       REQUIRES mbedtls)

--- a/components/auth/auth.c
+++ b/components/auth/auth.c
@@ -1,17 +1,42 @@
 #include "auth.h"
 #include "esp_log.h"
 #include <string.h>
+#include "mbedtls/sha256.h"
+
+static void sha256_hash(const char *input, unsigned char output[32])
+{
+    mbedtls_sha256_context ctx;
+    mbedtls_sha256_init(&ctx);
+    mbedtls_sha256_starts_ret(&ctx, 0);
+    mbedtls_sha256_update_ret(&ctx, (const unsigned char *)input, strlen(input));
+    mbedtls_sha256_finish_ret(&ctx, output);
+    mbedtls_sha256_free(&ctx);
+}
 
 static const char *TAG = "auth";
-static const char *stored_hash = "changeme"; // TODO: stocker un hash sécurisé
+static unsigned char stored_hash[32];
+static user_role_t current_role = ROLE_PARTICULIER;
 
 void auth_init(void)
 {
     ESP_LOGI(TAG, "Initialisation du module d'authentification");
+    auth_set_credentials("changeme", ROLE_PARTICULIER);
+}
+
+void auth_set_credentials(const char *password, user_role_t role)
+{
+    sha256_hash(password, stored_hash);
+    current_role = role;
 }
 
 bool auth_check(const char *password)
 {
-    // TODO: implémenter un hachage et une vérification sécurisée
-    return strcmp(password, stored_hash) == 0;
+    unsigned char hash[32];
+    sha256_hash(password, hash);
+    return memcmp(hash, stored_hash, sizeof(hash)) == 0;
+}
+
+user_role_t auth_get_role(void)
+{
+    return current_role;
 }

--- a/components/auth/auth.h
+++ b/components/auth/auth.h
@@ -1,14 +1,34 @@
 #ifndef AUTH_H
 #define AUTH_H
 
+#include <stdbool.h>
+
+/**
+ * \brief Rôles utilisateurs disponibles.
+ */
+typedef enum {
+    ROLE_PARTICULIER,  /**< Accès utilisateur particulier */
+    ROLE_PROFESSIONNEL /**< Accès utilisateur professionnel */
+} user_role_t;
+
 /**
  * \brief Initialise le système d'authentification.
  */
 void auth_init(void);
 
 /**
+ * \brief Définit les informations d'identification (hashage interne).
+ */
+void auth_set_credentials(const char *password, user_role_t role);
+
+/**
  * \brief Vérifie le mot de passe utilisateur.
  */
 bool auth_check(const char *password);
+
+/**
+ * \brief Récupère le rôle de l'utilisateur courant.
+ */
+user_role_t auth_get_role(void);
 
 #endif // AUTH_H

--- a/components/storage/CMakeLists.txt
+++ b/components/storage/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "storage.c"
-                       INCLUDE_DIRS ".")
+                       INCLUDE_DIRS "."
+                       REQUIRES mbedtls)

--- a/components/storage/storage.c
+++ b/components/storage/storage.c
@@ -1,7 +1,51 @@
 #include "storage.h"
 #include "esp_log.h"
+#include "mbedtls/aes.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
 
 static const char *TAG = "storage";
+static const unsigned char aes_key[16] = "lizard-secret!!";
+
+bool storage_encrypt_file(const char *path)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f)
+        return false;
+
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    long padded_len = (len + 15) & ~15;
+    unsigned char *buf = calloc(1, padded_len);
+    if (!buf) {
+        fclose(f);
+        return false;
+    }
+
+    fread(buf, 1, len, f);
+    fclose(f);
+
+    mbedtls_aes_context ctx;
+    mbedtls_aes_init(&ctx);
+    mbedtls_aes_setkey_enc(&ctx, aes_key, 128);
+    unsigned char iv[16] = {0};
+    mbedtls_aes_crypt_cbc(&ctx, MBEDTLS_AES_ENCRYPT, padded_len, iv, buf, buf);
+    mbedtls_aes_free(&ctx);
+
+    f = fopen(path, "wb");
+    if (!f) {
+        free(buf);
+        return false;
+    }
+
+    fwrite(buf, 1, padded_len, f);
+    fclose(f);
+    free(buf);
+    return true;
+}
 
 void storage_init(void)
 {
@@ -13,4 +57,11 @@ void storage_export(void)
 {
     ESP_LOGI(TAG, "Export des données");
     // TODO: exporter les données en CSV/JSON
+    const char *path = "/spiffs/export.enc";
+    FILE *f = fopen(path, "w");
+    if (f) {
+        fputs("placeholder", f);
+        fclose(f);
+        storage_encrypt_file(path);
+    }
 }

--- a/components/storage/storage.h
+++ b/components/storage/storage.h
@@ -1,6 +1,8 @@
 #ifndef STORAGE_H
 #define STORAGE_H
 
+#include <stdbool.h>
+
 /**
  * \brief Initialise le stockage externe (SD, SPIFFS...).
  */
@@ -10,5 +12,11 @@ void storage_init(void);
  * \brief Export des données en CSV ou JSON.
  */
 void storage_export(void);
+
+/**
+ * \brief Chiffre un fichier de stockage local.
+ * \param path Chemin du fichier à chiffrer.
+ */
+bool storage_encrypt_file(const char *path);
 
 #endif // STORAGE_H


### PR DESCRIPTION
## Summary
- add SHA-256 hashed passwords and user roles
- encrypt exported files with AES
- note security features in README

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f19e5d5d48323ae511484b833f3d7