### PR TITLE
Add sensor drivers component

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Projet ESP-IDF pour la gestion complète d'un élevage de reptiles. Ce dépôt f
 ## Structure
 - `main/` : point d'entrée de l'application.
  - `components/` : modules fonctionnels (base de données, UI, authentification,
-   gestion des animaux, des terrariums et génération de documents légaux).
+   gestion des animaux, des terrariums, **drivers de capteurs** et génération de
+   documents légaux).
    Les mots de passe sont hachés en SHA‑256 et les fichiers exportés sont chiffrés.
 - `docs/` : documentation légale et guides d'utilisation (voir `docs/UI_USAGE.md` pour l'interface).
 

--- a/components/drivers/CMakeLists.txt
+++ b/components/drivers/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "drivers.c"
+                       INCLUDE_DIRS ".")

--- a/components/drivers/drivers.c
+++ b/components/drivers/drivers.c
@@ -1,0 +1,40 @@
+#include "drivers.h"
+#include "esp_log.h"
+
+static const char *TAG = "drivers";
+
+static drivers_rest_hook_t rest_hook = NULL;
+static drivers_mqtt_hook_t mqtt_hook = NULL;
+
+void drivers_init(void)
+{
+    ESP_LOGI(TAG, "Initialisation des capteurs");
+    // Ici on pourrait initialiser de vrais capteurs I2C/SPI
+}
+
+sensor_data_t drivers_read(void)
+{
+    sensor_data_t data = {0};
+    // Valeurs simulées pour l'exemple
+    data.temperature_c = 25.0f;
+    data.humidity_percent = 50.0f;
+
+    ESP_LOGI(TAG, "Temp: %.1fC Hum: %.1f%%", data.temperature_c, data.humidity_percent);
+
+    if (rest_hook)
+        rest_hook(&data);
+    if (mqtt_hook)
+        mqtt_hook(&data);
+
+    return data;
+}
+
+void drivers_set_rest_hook(drivers_rest_hook_t hook)
+{
+    rest_hook = hook;
+}
+
+void drivers_set_mqtt_hook(drivers_mqtt_hook_t hook)
+{
+    mqtt_hook = hook;
+}

--- a/components/drivers/drivers.h
+++ b/components/drivers/drivers.h
@@ -1,0 +1,28 @@
+#ifndef DRIVERS_H
+#define DRIVERS_H
+
+#include <stdint.h>
+
+/**
+ * \brief Données lues par les capteurs.
+ */
+typedef struct {
+    float temperature_c;
+    float humidity_percent;
+} sensor_data_t;
+
+/** \brief Prototype pour extension REST. */
+typedef void (*drivers_rest_hook_t)(const sensor_data_t *data);
+
+/** \brief Prototype pour extension MQTT. */
+typedef void (*drivers_mqtt_hook_t)(const sensor_data_t *data);
+
+void drivers_init(void);
+
+sensor_data_t drivers_read(void);
+
+void drivers_set_rest_hook(drivers_rest_hook_t hook);
+
+void drivers_set_mqtt_hook(drivers_mqtt_hook_t hook);
+
+#endif // DRIVERS_H


### PR DESCRIPTION
## Summary
- add a new `drivers` component with stubs for temperature and humidity sensors
- expose hook registration for REST/MQTT extensions
- mention new drivers in the README

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1ac320ac83239a7102d7e38e1b44