### PR TITLE
Ajout README et notice légale en français

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,30 @@
 # LizardComette
 
-Projet ESP-IDF pour la gestion complète d'un élevage de reptiles. Ce dépôt fournit une structure de base pour développer une application embarquée sur ESP32 avec interface graphique LVGL et génération de documents légaux français et internationaux.
+LizardComette est un exemple de projet ESP‑IDF permettant de gérer un élevage de reptiles via une interface graphique LVGL. Il intègre des modules pour la base de données, l'authentification et la génération de documents légaux. Ce dépôt est fourni pour étude et nécessite une adaptation avant toute utilisation en production.
 
-## Structure
-- `main/` : point d'entrée de l'application.
-- `components/` : modules fonctionnels (base de données, UI, authentification,
-  gestion des animaux, des terrariums, **drivers de capteurs**, un **planificateur**
-  et génération de documents légaux).
-  - `scheduler/` : planificateur émettant des notifications sur les échéances,
-    le stock et la conformité.
-  Les mots de passe sont hachés en SHA‑256 et les fichiers exportés sont chiffrés.
-- `docs/` : documentation légale et guides d'utilisation (voir `docs/UI_USAGE.md` pour l'interface).
+## Fonctionnalités principales
+- Gestion des animaux et des terrariums.
+- Drivers pour capteurs environnementaux.
+- Planificateur avec notifications (stocks, échéances, conformité).
+- Génération de formulaires administratifs simplifiés.
+
+## Configuration
+1. Installez l'[ESP‑IDF](https://docs.espressif.com/).
+2. Définissez la variable `IDF_PATH` correspondant à votre installation.
+3. Inspirez‑vous de `docs/CONFIG_EXAMPLE.md` pour créer votre propre `sdkconfig` (Wi‑Fi, stockage, etc.).
+4. Placez vos fichiers de licences CITES et autres documents dans le répertoire approprié.
 
 ## Compilation
-1. Installer l'[ESP-IDF](https://docs.espressif.com/).
-2. Configurer l'environnement `IDF_PATH`.
-3. Lancer `idf.py set-target esp32` puis `idf.py build`.
+```bash
+idf.py set-target esp32
+idf.py build
+```
 
-## Avertissement
-Ce projet est fourni à titre d'exemple. Il ne garantit pas la conformité totale avec la législation. L'utilisateur doit vérifier chaque document généré.
+## Utilisation
+Une fois flashé sur votre ESP32, le firmware démarre l'interface graphique en français ou en anglais selon la configuration. Les modules s'initialisent automatiquement puis le planificateur vérifie les tâches à venir. Consultez `docs/UI_USAGE.md` pour le détail des écrans et `docs/NOTICE.md` pour les avertissements légaux.
+
+## Obligations et responsabilités
+Vous êtes seul responsable de la conformité des documents générés et du respect de la législation locale (France, Europe, international). Les exemples fournis ne constituent pas un conseil juridique et peuvent requérir l'avis d'un professionnel avant usage.
+
+## Licence
+Ce projet est distribué sous la licence MIT. Voir le fichier `LICENSE` pour plus de détails.

--- a/docs/NOTICE.md
+++ b/docs/NOTICE.md
@@ -1,3 +1,8 @@
-Ce projet contient des informations générales sur la gestion d'un élevage de reptiles.
-Il appartient à l'utilisateur de s'assurer de la conformité avec la réglementation en vigueur (France, Europe, international).
-Les modèles de formulaires inclus sont simplifiés et fournis à titre indicatif. Ils doivent être vérifiés et adaptés pour garantir leur validité juridique.
+# Notice légale
+
+Ce dépôt fournit des exemples de code et de documents pour faciliter la gestion d'un élevage de reptiles. Il ne constitue en aucun cas un conseil juridique. En utilisant ce projet, vous acceptez ce qui suit :
+
+- Vous demeurez responsable de vérifier la conformité de vos démarches et des formulaires générés.
+- Les textes et modèles inclus peuvent être incomplets ou obsolètes et nécessitent l'avis d'un professionnel.
+- L'auteur décline toute responsabilité quant aux conséquences d'une utilisation inappropriée ou non conforme à la législation.
+- Les paramètres de configuration présentés dans `docs/CONFIG_EXAMPLE.md` sont fournis à titre indicatif et doivent être adaptés à votre situation.


### PR DESCRIPTION
## Summary
- étend le README en français avec instructions de configuration et obligations
- complète `docs/NOTICE.md` pour rappeler la responsabilité de l'utilisateur
- ajoute un fichier LICENSE de type MIT

## Testing
- `idf.py --version` *(échoue car idf.py absent)*

------
https://chatgpt.com/codex/tasks/task_e_685f1e45384083238be08ff5b9130d78