### PR TITLE
Add stock and transaction modules

### DIFF
--- a/components/db/db.c
+++ b/components/db/db.c
@@ -46,6 +46,19 @@ void db_init(void)
                 "terrarium_id INTEGER,"
                 "message TEXT,"
                 "timestamp INTEGER DEFAULT (strftime('%s','now')));");
+
+    exec_simple("CREATE TABLE IF NOT EXISTS stocks(""
+                "id INTEGER PRIMARY KEY,""
+                "name TEXT,""
+                "quantity INTEGER,""
+                "min_quantity INTEGER);");
+
+    exec_simple("CREATE TABLE IF NOT EXISTS transactions(""
+                "id INTEGER PRIMARY KEY AUTOINCREMENT,""
+                "stock_id INTEGER,""
+                "quantity INTEGER,""
+                "type TEXT,""
+                "timestamp INTEGER DEFAULT (strftime('%s','now')));");
 }
 
 void db_backup(void)
@@ -115,6 +128,49 @@ static void export_terrariums_csv(FILE *f)
     fprintf(f, "\n");
 }
 
+static void export_stocks_csv(FILE *f)
+{
+    fprintf(f, "stocks\n");
+    fprintf(f, "id,name,quantity,min_quantity\n");
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(db_handle,
+                           "SELECT id,name,quantity,min_quantity FROM stocks;",
+                           -1, &stmt, NULL) == SQLITE_OK) {
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            fprintf(f, "%d,%s,%d,%d\n",
+                    sqlite3_column_int(stmt, 0),
+                    sqlite3_column_text(stmt, 1),
+                    sqlite3_column_int(stmt, 2),
+                    sqlite3_column_int(stmt, 3));
+        }
+        sqlite3_finalize(stmt);
+    }
+    fprintf(f, "\n");
+}
+
+static void export_transactions_csv(FILE *f)
+{
+    fprintf(f, "transactions\n");
+    fprintf(f, "id,stock_id,quantity,type,timestamp\n");
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(db_handle,
+                           "SELECT id,stock_id,quantity,type,timestamp FROM transactions;",
+                           -1, &stmt, NULL) == SQLITE_OK) {
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            fprintf(f, "%d,%d,%d,%s,%d\n",
+                    sqlite3_column_int(stmt, 0),
+                    sqlite3_column_int(stmt, 1),
+                    sqlite3_column_int(stmt, 2),
+                    sqlite3_column_text(stmt, 3),
+                    sqlite3_column_int(stmt, 4));
+        }
+        sqlite3_finalize(stmt);
+    }
+    fprintf(f, "\n");
+}
+
 void db_export_csv(const char *path)
 {
     if (!db_handle || !path)
@@ -128,6 +184,8 @@ void db_export_csv(const char *path)
 
     export_animals_csv(f);
     export_terrariums_csv(f);
+    export_stocks_csv(f);
+    export_transactions_csv(f);
 
     fclose(f);
     ESP_LOGI(TAG, "Export CSV vers %s termine", path);
@@ -181,6 +239,51 @@ static void export_terrariums_json(FILE *f)
     fprintf(f, "\n  ]\n");
 }
 
+static void export_stocks_json(FILE *f)
+{
+    fprintf(f, "  \"stocks\": [\n");
+    sqlite3_stmt *stmt;
+    bool first = true;
+    if (sqlite3_prepare_v2(db_handle,
+                           "SELECT id,name,quantity,min_quantity FROM stocks;",
+                           -1, &stmt, NULL) == SQLITE_OK) {
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            if (!first) fprintf(f, ",\n");
+            first = false;
+            fprintf(f, "    {\"id\":%d,\"name\":\"%s\",\"quantity\":%d,\"min_quantity\":%d}",
+                    sqlite3_column_int(stmt, 0),
+                    sqlite3_column_text(stmt, 1),
+                    sqlite3_column_int(stmt, 2),
+                    sqlite3_column_int(stmt, 3));
+        }
+        sqlite3_finalize(stmt);
+    }
+    fprintf(f, "\n  ],\n");
+}
+
+static void export_transactions_json(FILE *f)
+{
+    fprintf(f, "  \"transactions\": [\n");
+    sqlite3_stmt *stmt;
+    bool first = true;
+    if (sqlite3_prepare_v2(db_handle,
+                           "SELECT id,stock_id,quantity,type,timestamp FROM transactions;",
+                           -1, &stmt, NULL) == SQLITE_OK) {
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            if (!first) fprintf(f, ",\n");
+            first = false;
+            fprintf(f, "    {\"id\":%d,\"stock_id\":%d,\"quantity\":%d,\"type\":\"%s\",\"timestamp\":%d}",
+                    sqlite3_column_int(stmt, 0),
+                    sqlite3_column_int(stmt, 1),
+                    sqlite3_column_int(stmt, 2),
+                    sqlite3_column_text(stmt, 3),
+                    sqlite3_column_int(stmt, 4));
+        }
+        sqlite3_finalize(stmt);
+    }
+    fprintf(f, "\n  ]\n");
+}
+
 void db_export_json(const char *path)
 {
     if (!db_handle || !path)
@@ -196,6 +299,10 @@ void db_export_json(const char *path)
     export_animals_json(f);
     fprintf(f, ",\n");
     export_terrariums_json(f);
+    fprintf(f, ",\n");
+    export_stocks_json(f);
+    fprintf(f, ",\n");
+    export_transactions_json(f);
     fprintf(f, "}\n");
 
     fclose(f);

--- a/components/scheduler/scheduler.c
+++ b/components/scheduler/scheduler.c
@@ -3,6 +3,7 @@
 #include "freertos/task.h"
 #include "esp_log.h"
 #include "ui.h"
+#include "stocks.h"
 
 #define SCHEDULER_INTERVAL_MS 60000
 
@@ -21,7 +22,14 @@ static void check_regulatory_deadlines(void)
 
 static void check_stock_levels(void)
 {
-    notify("Verification des niveaux de stock");
+    for (int i = 0; i < stocks_count(); ++i) {
+        const StockItem *it = stocks_get_by_index(i);
+        if (it && it->quantity <= it->min_quantity) {
+            char msg[64];
+            snprintf(msg, sizeof(msg), "Stock bas: %s", it->name);
+            notify(msg);
+        }
+    }
 }
 
 static void check_compliance(void)

--- a/components/stocks/CMakeLists.txt
+++ b/components/stocks/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "stocks.c"
+                       INCLUDE_DIRS ".")

--- a/components/stocks/stocks.c
+++ b/components/stocks/stocks.c
@@ -1,0 +1,78 @@
+#include "stocks.h"
+#include "esp_log.h"
+#include <string.h>
+
+static const char *TAG = "stocks";
+
+static StockItem stock_items[STOCKS_MAX];
+static int stock_count = 0;
+
+void stocks_init(void)
+{
+    stock_count = 0;
+    memset(stock_items, 0, sizeof(stock_items));
+    ESP_LOGI(TAG, "Initialisation des stocks");
+}
+
+static int find_index(int id)
+{
+    for (int i = 0; i < stock_count; ++i) {
+        if (stock_items[i].id == id)
+            return i;
+    }
+    return -1;
+}
+
+bool stocks_add(const StockItem *item)
+{
+    if (stock_count >= STOCKS_MAX || !item)
+        return false;
+    stock_items[stock_count] = *item;
+    stock_count++;
+    ESP_LOGI(TAG, "Ajout de l'article %d", item->id);
+    return true;
+}
+
+const StockItem *stocks_get(int id)
+{
+    int idx = find_index(id);
+    if (idx >= 0)
+        return &stock_items[idx];
+    return NULL;
+}
+
+bool stocks_update(int id, const StockItem *item)
+{
+    int idx = find_index(id);
+    if (idx < 0 || !item)
+        return false;
+    stock_items[idx] = *item;
+    ESP_LOGI(TAG, "Mise a jour de l'article %d", id);
+    return true;
+}
+
+bool stocks_delete(int id)
+{
+    int idx = find_index(id);
+    if (idx < 0)
+        return false;
+    for (int i = idx; i < stock_count - 1; ++i) {
+        stock_items[i] = stock_items[i + 1];
+    }
+    stock_count--;
+    ESP_LOGI(TAG, "Suppression de l'article %d", id);
+    return true;
+}
+
+int stocks_count(void)
+{
+    return stock_count;
+}
+
+const StockItem *stocks_get_by_index(int index)
+{
+    if (index < 0 || index >= stock_count)
+        return NULL;
+    return &stock_items[index];
+}
+

--- a/components/stocks/stocks.h
+++ b/components/stocks/stocks.h
@@ -1,0 +1,23 @@
+#ifndef STOCKS_H
+#define STOCKS_H
+
+#include <stdbool.h>
+
+#define STOCKS_MAX 50
+
+typedef struct {
+    int id;
+    char name[32];
+    int quantity;
+    int min_quantity;
+} StockItem;
+
+void stocks_init(void);
+bool stocks_add(const StockItem *item);
+const StockItem *stocks_get(int id);
+bool stocks_update(int id, const StockItem *item);
+bool stocks_delete(int id);
+int stocks_count(void);
+const StockItem *stocks_get_by_index(int index);
+
+#endif // STOCKS_H

--- a/components/transactions/CMakeLists.txt
+++ b/components/transactions/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "transactions.c"
+                       INCLUDE_DIRS ".")

--- a/components/transactions/transactions.c
+++ b/components/transactions/transactions.c
@@ -1,0 +1,66 @@
+#include "transactions.h"
+#include "esp_log.h"
+#include <string.h>
+
+static const char *TAG = "transactions";
+
+static Transaction transactions[TRANSACTIONS_MAX];
+static int transaction_count = 0;
+
+void transactions_init(void)
+{
+    transaction_count = 0;
+    memset(transactions, 0, sizeof(transactions));
+    ESP_LOGI(TAG, "Initialisation des transactions");
+}
+
+static int find_index(int id)
+{
+    for (int i = 0; i < transaction_count; ++i) {
+        if (transactions[i].id == id)
+            return i;
+    }
+    return -1;
+}
+
+bool transactions_add(const Transaction *t)
+{
+    if (transaction_count >= TRANSACTIONS_MAX || !t)
+        return false;
+    transactions[transaction_count] = *t;
+    transaction_count++;
+    ESP_LOGI(TAG, "Ajout de la transaction %d", t->id);
+    return true;
+}
+
+const Transaction *transactions_get(int id)
+{
+    int idx = find_index(id);
+    if (idx >= 0)
+        return &transactions[idx];
+    return NULL;
+}
+
+bool transactions_update(int id, const Transaction *t)
+{
+    int idx = find_index(id);
+    if (idx < 0 || !t)
+        return false;
+    transactions[idx] = *t;
+    ESP_LOGI(TAG, "Mise a jour de la transaction %d", id);
+    return true;
+}
+
+bool transactions_delete(int id)
+{
+    int idx = find_index(id);
+    if (idx < 0)
+        return false;
+    for (int i = idx; i < transaction_count - 1; ++i) {
+        transactions[i] = transactions[i + 1];
+    }
+    transaction_count--;
+    ESP_LOGI(TAG, "Suppression de la transaction %d", id);
+    return true;
+}
+

--- a/components/transactions/transactions.h
+++ b/components/transactions/transactions.h
@@ -1,0 +1,26 @@
+#ifndef TRANSACTIONS_H
+#define TRANSACTIONS_H
+
+#include <stdbool.h>
+
+#define TRANSACTIONS_MAX 100
+
+typedef enum {
+    TRANSACTION_PURCHASE,
+    TRANSACTION_SALE
+} transaction_type_t;
+
+typedef struct {
+    int id;
+    int stock_id;
+    int quantity;
+    transaction_type_t type;
+} Transaction;
+
+void transactions_init(void);
+bool transactions_add(const Transaction *t);
+const Transaction *transactions_get(int id);
+bool transactions_update(int id, const Transaction *t);
+bool transactions_delete(int id);
+
+#endif // TRANSACTIONS_H

--- a/main/main.c
+++ b/main/main.c
@@ -10,6 +10,8 @@
 #include "storage.h"
 #include "animals.h"
 #include "terrariums.h"
+#include "stocks.h"
+#include "transactions.h"
 #include "scheduler.h"
 
 /**
@@ -33,6 +35,8 @@ void app_main(void)
     // Initialisation des modules metier
     animals_init();
     terrariums_init();
+    stocks_init();
+    transactions_init();
     scheduler_init();
 
     // Boucle principale


### PR DESCRIPTION
## Summary
- add `stocks` and `transactions` components
- support inventory and purchase/sale records in DB
- trigger stock alerts from scheduler
- initialize new modules in `main`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fcd100c588323a47d63029d5ce179