### PR TITLE
Add legal quota checks and official forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ LizardComette est un exemple de projet ESP‑IDF permettant de gérer un élevag
 - Drivers pour capteurs environnementaux.
 - Planificateur avec notifications (stocks, échéances, conformité).
 - Génération de formulaires administratifs simplifiés.
+- Support du CDC/AOE, gestion des quotas et formulaires CERFA/CITES officiels.
 
 ## Configuration
 1. Installez l'[ESP‑IDF](https://docs.espressif.com/).

--- a/components/animals/animals.c
+++ b/components/animals/animals.c
@@ -63,3 +63,15 @@ bool animals_delete(int id)
     ESP_LOGI(TAG, "Suppression du reptile %d", id);
     return true;
 }
+
+int animals_count(void)
+{
+    return animal_count;
+}
+
+const Reptile *animals_get_by_index(int index)
+{
+    if (index < 0 || index >= animal_count)
+        return NULL;
+    return &animals[index];
+}

--- a/components/animals/animals.h
+++ b/components/animals/animals.h
@@ -16,6 +16,13 @@ typedef struct {
     char birth_date[16];
     char health[64];
     char breeding_cycle[64];
+    char cdc_number[32];
+    char aoe_number[32];
+    char ifap_id[32];
+    int quota_limit;
+    int quota_used;
+    int cerfa_valid_until;
+    int cites_valid_until;
 } Reptile;
 
 /**
@@ -42,5 +49,8 @@ bool animals_update(int id, const Reptile *r);
  * \brief Supprime un reptile par id.
  */
 bool animals_delete(int id);
+
+int animals_count(void);
+const Reptile *animals_get_by_index(int index);
 
 #endif // ANIMALS_H

--- a/components/legal/legal.c
+++ b/components/legal/legal.c
@@ -3,6 +3,7 @@
 #include "esp_log.h"
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 static const char *TAG = "legal";
 
@@ -75,6 +76,64 @@ bool legal_generate_invoice(const char *path, const Reptile *r)
     return write_basic_pdf(path, buffer);
 }
 
+bool legal_generate_cerfa_official(const char *path, const Reptile *r)
+{
+    if (!r)
+        return false;
+    char buffer[512];
+    snprintf(buffer, sizeof(buffer), cerfa_official_template,
+             r->name, r->species, r->sex, r->birth_date,
+             r->cdc_number, r->aoe_number, r->ifap_id,
+             r->quota_used, r->quota_limit);
+    return write_basic_pdf(path, buffer);
+}
+
+bool legal_generate_cites_official(const char *path, const Reptile *r)
+{
+    if (!r)
+        return false;
+    char buffer[256];
+    snprintf(buffer, sizeof(buffer), cites_official_template,
+             r->name, r->species, r->ifap_id);
+    return write_basic_pdf(path, buffer);
+}
+
+bool legal_is_cerfa_valid(const Reptile *r)
+{
+    if (!r)
+        return false;
+    return r->cerfa_valid_until > (int)time(NULL);
+}
+
+bool legal_is_cites_valid(const Reptile *r)
+{
+    if (!r)
+        return false;
+    return r->cites_valid_until > (int)time(NULL);
+}
+
+bool legal_quota_remaining(const Reptile *r)
+{
+    if (!r)
+        return false;
+    return r->quota_used < r->quota_limit;
+}
+
+void legal_check_documents(void)
+{
+    for (int i = 0; i < animals_count(); ++i) {
+        const Reptile *r = animals_get_by_index(i);
+        if (!r)
+            continue;
+        if (!legal_is_cerfa_valid(r) || !legal_is_cites_valid(r)) {
+            ESP_LOGW(TAG, "Documents expir\xC3\xA9s pour %s", r->name);
+        }
+        if (!legal_quota_remaining(r)) {
+            ESP_LOGW(TAG, "Quota atteint pour %s", r->name);
+        }
+    }
+}
+
 void legal_generate_all(const char *dir, const Reptile *r)
 {
     if (!dir || !r)
@@ -83,11 +142,17 @@ void legal_generate_all(const char *dir, const Reptile *r)
     snprintf(path, sizeof(path), "%s/cerfa.pdf", dir);
     legal_generate_cerfa(path, r);
 
+    snprintf(path, sizeof(path), "%s/cerfa_officiel.pdf", dir);
+    legal_generate_cerfa_official(path, r);
+
     snprintf(path, sizeof(path), "%s/ifap.pdf", dir);
     legal_generate_ifap(path, r);
 
     snprintf(path, sizeof(path), "%s/cites.pdf", dir);
     legal_generate_cites(path, r);
+
+    snprintf(path, sizeof(path), "%s/cites_officiel.pdf", dir);
+    legal_generate_cites_official(path, r);
 
     snprintf(path, sizeof(path), "%s/invoice.pdf", dir);
     legal_generate_invoice(path, r);

--- a/components/legal/legal.h
+++ b/components/legal/legal.h
@@ -8,6 +8,14 @@ bool legal_generate_cerfa(const char *path, const Reptile *r);
 bool legal_generate_ifap(const char *path, const Reptile *r);
 bool legal_generate_cites(const char *path, const Reptile *r);
 bool legal_generate_invoice(const char *path, const Reptile *r);
+bool legal_generate_cerfa_official(const char *path, const Reptile *r);
+bool legal_generate_cites_official(const char *path, const Reptile *r);
+
+bool legal_is_cerfa_valid(const Reptile *r);
+bool legal_is_cites_valid(const Reptile *r);
+bool legal_quota_remaining(const Reptile *r);
+
+void legal_check_documents(void);
 
 void legal_generate_all(const char *dir, const Reptile *r);
 

--- a/components/legal/legal_templates.c
+++ b/components/legal/legal_templates.c
@@ -22,3 +22,20 @@ const char invoice_template[] =
     "Facture\n"
     "Animal: %s\n"
     "Espece: %s\n";
+
+const char cerfa_official_template[] =
+    "CERFA Officiel\n"
+    "Nom: %s\n"
+    "Espece: %s\n"
+    "Sexe: %s\n"
+    "Date de naissance: %s\n"
+    "CDC: %s\n"
+    "AOE: %s\n"
+    "I-FAP: %s\n"
+    "Quota: %d/%d\n";
+
+const char cites_official_template[] =
+    "CITES Officiel\n"
+    "Nom: %s\n"
+    "Espece: %s\n"
+    "I-FAP: %s\n";

--- a/components/legal/legal_templates.h
+++ b/components/legal/legal_templates.h
@@ -5,5 +5,7 @@ extern const char cerfa_template[];
 extern const char ifap_template[];
 extern const char cites_template[];
 extern const char invoice_template[];
+extern const char cerfa_official_template[];
+extern const char cites_official_template[];
 
 #endif // LEGAL_TEMPLATES_H

--- a/components/scheduler/scheduler.c
+++ b/components/scheduler/scheduler.c
@@ -4,6 +4,7 @@
 #include "esp_log.h"
 #include "ui.h"
 #include "stocks.h"
+#include "legal.h"
 
 #define SCHEDULER_INTERVAL_MS 60000
 
@@ -18,6 +19,7 @@ static void notify(const char *msg)
 static void check_regulatory_deadlines(void)
 {
     notify("Verification des echeances reglementaires");
+    legal_check_documents();
 }
 
 static void check_stock_levels(void)


### PR DESCRIPTION
## Summary
- add CDC/AOE/I-FAP fields to `Reptile`
- expose iteration helpers in `animals`
- extend legal templates with official CERFA/CITES forms
- generate and validate official documents in `legal`
- verify document deadlines from the scheduler
- document new legal features in README

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcee240948323a23b9382727edbc3