### PR TITLE
Add multi-user auth and elevage separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ LizardComette est un exemple de projet ESP‑IDF permettant de gérer un élevag
 
 ## Fonctionnalités principales
 - Gestion des animaux et des terrariums.
+- Authentification multi-utilisateur avec mots de passe hachés et rôles.
+- Séparation des données par identifiant d'élevage pour les animaux et terrariums.
 - Drivers pour capteurs environnementaux.
 - Planificateur avec notifications (stocks, échéances, conformité).
 - Génération de formulaires administratifs simplifiés.

--- a/components/animals/animals.c
+++ b/components/animals/animals.c
@@ -75,3 +75,26 @@ const Reptile *animals_get_by_index(int index)
         return NULL;
     return &animals[index];
 }
+
+int animals_count_for_elevage(int elevage_id)
+{
+    int count = 0;
+    for (int i = 0; i < animal_count; ++i) {
+        if (animals[i].elevage_id == elevage_id)
+            count++;
+    }
+    return count;
+}
+
+const Reptile *animals_get_by_index_for_elevage(int index, int elevage_id)
+{
+    int current = 0;
+    for (int i = 0; i < animal_count; ++i) {
+        if (animals[i].elevage_id == elevage_id) {
+            if (current == index)
+                return &animals[i];
+            current++;
+        }
+    }
+    return NULL;
+}

--- a/components/animals/animals.h
+++ b/components/animals/animals.h
@@ -10,6 +10,7 @@
  */
 typedef struct {
     int id;
+    int elevage_id;
     char name[32];
     char species[32];
     char sex[8];
@@ -52,5 +53,8 @@ bool animals_delete(int id);
 
 int animals_count(void);
 const Reptile *animals_get_by_index(int index);
+
+int animals_count_for_elevage(int elevage_id);
+const Reptile *animals_get_by_index_for_elevage(int index, int elevage_id);
 
 #endif // ANIMALS_H

--- a/components/auth/auth.c
+++ b/components/auth/auth.c
@@ -14,29 +14,45 @@ static void sha256_hash(const char *input, unsigned char output[32])
 }
 
 static const char *TAG = "auth";
-static unsigned char stored_hash[32];
-static user_role_t current_role = ROLE_PARTICULIER;
+static auth_user_t users[AUTH_MAX_USERS];
+static int user_count = 0;
 
 void auth_init(void)
 {
     ESP_LOGI(TAG, "Initialisation du module d'authentification");
-    auth_set_credentials("changeme", ROLE_PARTICULIER);
+    user_count = 0;
+    auth_add_user("admin", "changeme", ROLE_PARTICULIER);
 }
 
-void auth_set_credentials(const char *password, user_role_t role)
+bool auth_add_user(const char *username, const char *password, user_role_t role)
 {
-    sha256_hash(password, stored_hash);
-    current_role = role;
+    if (user_count >= AUTH_MAX_USERS || !username || !password)
+        return false;
+    strncpy(users[user_count].username, username, sizeof(users[user_count].username) - 1);
+    users[user_count].username[sizeof(users[user_count].username) - 1] = '\0';
+    sha256_hash(password, users[user_count].hash);
+    users[user_count].role = role;
+    user_count++;
+    return true;
 }
 
-bool auth_check(const char *password)
+bool auth_check(const char *username, const char *password)
 {
     unsigned char hash[32];
     sha256_hash(password, hash);
-    return memcmp(hash, stored_hash, sizeof(hash)) == 0;
+    for (int i = 0; i < user_count; ++i) {
+        if (strcmp(users[i].username, username) == 0 &&
+            memcmp(users[i].hash, hash, sizeof(hash)) == 0)
+            return true;
+    }
+    return false;
 }
 
-user_role_t auth_get_role(void)
+user_role_t auth_get_role(const char *username)
 {
-    return current_role;
+    for (int i = 0; i < user_count; ++i) {
+        if (strcmp(users[i].username, username) == 0)
+            return users[i].role;
+    }
+    return ROLE_PARTICULIER;
 }

--- a/components/auth/auth.h
+++ b/components/auth/auth.h
@@ -11,24 +11,32 @@ typedef enum {
     ROLE_PROFESSIONNEL /**< Accès utilisateur professionnel */
 } user_role_t;
 
+#define AUTH_MAX_USERS 5
+
+typedef struct {
+    char username[32];
+    unsigned char hash[32];
+    user_role_t role;
+} auth_user_t;
+
 /**
  * \brief Initialise le système d'authentification.
  */
 void auth_init(void);
 
 /**
- * \brief Définit les informations d'identification (hashage interne).
+ * \brief Ajoute un utilisateur avec mot de passe haché.
  */
-void auth_set_credentials(const char *password, user_role_t role);
+bool auth_add_user(const char *username, const char *password, user_role_t role);
 
 /**
  * \brief Vérifie le mot de passe utilisateur.
  */
-bool auth_check(const char *password);
+bool auth_check(const char *username, const char *password);
 
 /**
- * \brief Récupère le rôle de l'utilisateur courant.
+ * \brief Récupère le rôle d'un utilisateur.
  */
-user_role_t auth_get_role(void);
+user_role_t auth_get_role(const char *username);
 
 #endif // AUTH_H

--- a/components/db/db.c
+++ b/components/db/db.c
@@ -27,6 +27,7 @@ void db_init(void)
 
     exec_simple("CREATE TABLE IF NOT EXISTS animals("
                 "id INTEGER PRIMARY KEY,"
+                "elevage_id INTEGER,"
                 "name TEXT,"
                 "species TEXT,"
                 "sex TEXT,"
@@ -36,6 +37,7 @@ void db_init(void)
 
     exec_simple("CREATE TABLE IF NOT EXISTS terrariums("
                 "id INTEGER PRIMARY KEY,"
+                "elevage_id INTEGER,"
                 "name TEXT,"
                 "capacity INTEGER,"
                 "inventory TEXT,"
@@ -85,21 +87,22 @@ void db_backup(void)
 static void export_animals_csv(FILE *f)
 {
     fprintf(f, "animals\n");
-    fprintf(f, "id,name,species,sex,birth_date,health,breeding_cycle\n");
+    fprintf(f, "id,elevage_id,name,species,sex,birth_date,health,breeding_cycle\n");
 
     sqlite3_stmt *stmt;
     if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,name,species,sex,birth_date,health,breeding_cycle FROM animals;",
+                           "SELECT id,elevage_id,name,species,sex,birth_date,health,breeding_cycle FROM animals;",
                            -1, &stmt, NULL) == SQLITE_OK) {
         while (sqlite3_step(stmt) == SQLITE_ROW) {
-            fprintf(f, "%d,%s,%s,%s,%s,%s,%s\n",
+            fprintf(f, "%d,%d,%s,%s,%s,%s,%s,%s\n",
                     sqlite3_column_int(stmt, 0),
-                    sqlite3_column_text(stmt, 1),
+                    sqlite3_column_int(stmt, 1),
                     sqlite3_column_text(stmt, 2),
                     sqlite3_column_text(stmt, 3),
                     sqlite3_column_text(stmt, 4),
                     sqlite3_column_text(stmt, 5),
-                    sqlite3_column_text(stmt, 6));
+                    sqlite3_column_text(stmt, 6),
+                    sqlite3_column_text(stmt, 7));
         }
         sqlite3_finalize(stmt);
     }
@@ -109,19 +112,20 @@ static void export_animals_csv(FILE *f)
 static void export_terrariums_csv(FILE *f)
 {
     fprintf(f, "terrariums\n");
-    fprintf(f, "id,name,capacity,inventory,notes\n");
+    fprintf(f, "id,elevage_id,name,capacity,inventory,notes\n");
 
     sqlite3_stmt *stmt;
     if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,name,capacity,inventory,notes FROM terrariums;",
+                           "SELECT id,elevage_id,name,capacity,inventory,notes FROM terrariums;",
                            -1, &stmt, NULL) == SQLITE_OK) {
         while (sqlite3_step(stmt) == SQLITE_ROW) {
-            fprintf(f, "%d,%s,%d,%s,%s\n",
+            fprintf(f, "%d,%d,%s,%d,%s,%s\n",
                     sqlite3_column_int(stmt, 0),
-                    sqlite3_column_text(stmt, 1),
-                    sqlite3_column_int(stmt, 2),
-                    sqlite3_column_text(stmt, 3),
-                    sqlite3_column_text(stmt, 4));
+                    sqlite3_column_int(stmt, 1),
+                    sqlite3_column_text(stmt, 2),
+                    sqlite3_column_int(stmt, 3),
+                    sqlite3_column_text(stmt, 4),
+                    sqlite3_column_text(stmt, 5));
         }
         sqlite3_finalize(stmt);
     }
@@ -197,19 +201,20 @@ static void export_animals_json(FILE *f)
     sqlite3_stmt *stmt;
     bool first = true;
     if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,name,species,sex,birth_date,health,breeding_cycle FROM animals;",
+                           "SELECT id,elevage_id,name,species,sex,birth_date,health,breeding_cycle FROM animals;",
                            -1, &stmt, NULL) == SQLITE_OK) {
         while (sqlite3_step(stmt) == SQLITE_ROW) {
             if (!first) fprintf(f, ",\n");
             first = false;
-            fprintf(f, "    {\"id\":%d,\"name\":\"%s\",\"species\":\"%s\",\"sex\":\"%s\",\"birth_date\":\"%s\",\"health\":\"%s\",\"breeding_cycle\":\"%s\"}",
+            fprintf(f, "    {\"id\":%d,\"elevage_id\":%d,\"name\":\"%s\",\"species\":\"%s\",\"sex\":\"%s\",\"birth_date\":\"%s\",\"health\":\"%s\",\"breeding_cycle\":\"%s\"}",
                     sqlite3_column_int(stmt, 0),
-                    sqlite3_column_text(stmt, 1),
+                    sqlite3_column_int(stmt, 1),
                     sqlite3_column_text(stmt, 2),
                     sqlite3_column_text(stmt, 3),
                     sqlite3_column_text(stmt, 4),
                     sqlite3_column_text(stmt, 5),
-                    sqlite3_column_text(stmt, 6));
+                    sqlite3_column_text(stmt, 6),
+                    sqlite3_column_text(stmt, 7));
         }
         sqlite3_finalize(stmt);
     }
@@ -222,17 +227,18 @@ static void export_terrariums_json(FILE *f)
     sqlite3_stmt *stmt;
     bool first = true;
     if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,name,capacity,inventory,notes FROM terrariums;",
+                           "SELECT id,elevage_id,name,capacity,inventory,notes FROM terrariums;",
                            -1, &stmt, NULL) == SQLITE_OK) {
         while (sqlite3_step(stmt) == SQLITE_ROW) {
             if (!first) fprintf(f, ",\n");
             first = false;
-            fprintf(f, "    {\"id\":%d,\"name\":\"%s\",\"capacity\":%d,\"inventory\":\"%s\",\"notes\":\"%s\"}",
+            fprintf(f, "    {\"id\":%d,\"elevage_id\":%d,\"name\":\"%s\",\"capacity\":%d,\"inventory\":\"%s\",\"notes\":\"%s\"}",
                     sqlite3_column_int(stmt, 0),
-                    sqlite3_column_text(stmt, 1),
-                    sqlite3_column_int(stmt, 2),
-                    sqlite3_column_text(stmt, 3),
-                    sqlite3_column_text(stmt, 4));
+                    sqlite3_column_int(stmt, 1),
+                    sqlite3_column_text(stmt, 2),
+                    sqlite3_column_int(stmt, 3),
+                    sqlite3_column_text(stmt, 4),
+                    sqlite3_column_text(stmt, 5));
         }
         sqlite3_finalize(stmt);
     }

--- a/components/terrariums/terrariums.c
+++ b/components/terrariums/terrariums.c
@@ -76,3 +76,26 @@ void terrariums_log_transaction(const char *msg)
     ESP_LOGI(TAG, "Log: %s", logs[log_count]);
     log_count++;
 }
+
+int terrariums_count_for_elevage(int elevage_id)
+{
+    int count = 0;
+    for (int i = 0; i < terrarium_count; ++i) {
+        if (terrariums[i].elevage_id == elevage_id)
+            count++;
+    }
+    return count;
+}
+
+const Terrarium *terrariums_get_by_index_for_elevage(int index, int elevage_id)
+{
+    int current = 0;
+    for (int i = 0; i < terrarium_count; ++i) {
+        if (terrariums[i].elevage_id == elevage_id) {
+            if (current == index)
+                return &terrariums[i];
+            current++;
+        }
+    }
+    return NULL;
+}

--- a/components/terrariums/terrariums.h
+++ b/components/terrariums/terrariums.h
@@ -11,6 +11,7 @@
  */
 typedef struct {
     int id;
+    int elevage_id;
     char name[32];
     int capacity;
     char inventory[64];
@@ -46,5 +47,8 @@ bool terrariums_delete(int id);
  * \brief Enregistre une transaction ou un événement dans les logs.
  */
 void terrariums_log_transaction(const char *msg);
+
+int terrariums_count_for_elevage(int elevage_id);
+const Terrarium *terrariums_get_by_index_for_elevage(int index, int elevage_id);
 
 #endif // TERRARIUMS_H


### PR DESCRIPTION
## Summary
- support multiple users with hashed passwords and roles
- link animals and terrariums to an élevage identifier
- expose helpers to filter by élevage
- update SQLite schema and exports
- document the new behavior in README

## Testing
- `cmake .` *(fails: include could not find project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_685fd1f271b0832389d839a04398c4dd