### PR TITLE
Add LVGL management forms and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 LizardComette est un exemple de projet ESP‑IDF permettant de gérer un élevage de reptiles via une interface graphique LVGL. Il intègre des modules pour la base de données, l'authentification et la génération de documents légaux. Ce dépôt est fourni pour étude et nécessite une adaptation avant toute utilisation en production.
 
 ## Fonctionnalités principales
-- Gestion des animaux et des terrariums.
+- Gestion des animaux, des terrariums, du stock et des transactions.
 - Authentification multi-utilisateur avec mots de passe hachés et rôles.
 - Séparation des données par identifiant d'élevage pour les animaux et terrariums.
 - Drivers I2C/SPI pour capteurs environnementaux avec envoi REST/MQTT.

--- a/components/transactions/transactions.c
+++ b/components/transactions/transactions.c
@@ -64,3 +64,15 @@ bool transactions_delete(int id)
     return true;
 }
 
+int transactions_count(void)
+{
+    return transaction_count;
+}
+
+const Transaction *transactions_get_by_index(int index)
+{
+    if (index < 0 || index >= transaction_count)
+        return NULL;
+    return &transactions[index];
+}
+

--- a/components/transactions/transactions.h
+++ b/components/transactions/transactions.h
@@ -22,5 +22,7 @@ bool transactions_add(const Transaction *t);
 const Transaction *transactions_get(int id);
 bool transactions_update(int id, const Transaction *t);
 bool transactions_delete(int id);
+int transactions_count(void);
+const Transaction *transactions_get_by_index(int index);
 
 #endif // TRANSACTIONS_H

--- a/components/ui/ui.c
+++ b/components/ui/ui.c
@@ -1,5 +1,11 @@
 #include "ui.h"
 #include "esp_log.h"
+#include "animals.h"
+#include "terrariums.h"
+#include "stocks.h"
+#include "transactions.h"
+#include "legal.h"
+#include "storage.h"
 
 static const char *TAG = "ui";
 
@@ -10,17 +16,138 @@ static const char *translations[UI_LANG_COUNT][TXT_COUNT] = {
     [UI_LANG_EN] = {
         [TXT_ANIMALS] = "Animals",
         [TXT_TERRARIUMS] = "Terrariums",
+        [TXT_STOCKS] = "Stock",
+        [TXT_TRANSACTIONS] = "Transactions",
         [TXT_SETTINGS] = "Settings",
+        [TXT_EXPORT] = "Export",
+        [TXT_IMPORT] = "Import",
+        [TXT_LEGAL_OK] = "OK",
+        [TXT_LEGAL_EXPIRED] = "Expired",
+        [TXT_LANGUAGE] = "Language",
+        [TXT_THEME] = "Theme",
     },
     [UI_LANG_FR] = {
         [TXT_ANIMALS] = "Animaux",
         [TXT_TERRARIUMS] = "Terrariums",
+        [TXT_STOCKS] = "Stocks",
+        [TXT_TRANSACTIONS] = "Transactions",
         [TXT_SETTINGS] = "Param\xC3\xA8tres",
+        [TXT_EXPORT] = "Exporter",
+        [TXT_IMPORT] = "Importer",
+        [TXT_LEGAL_OK] = "OK",
+        [TXT_LEGAL_EXPIRED] = "Expire",
+        [TXT_LANGUAGE] = "Langue",
+        [TXT_THEME] = "Th\xC3\xA8me",
     }
 };
 
 static lv_obj_t *tabview;
 static lv_obj_t *notif_label;
+
+static void animals_tab_create(lv_obj_t *tab)
+{
+    lv_obj_t *list = lv_list_create(tab);
+    lv_obj_set_size(list, 380, 420);
+    for (int i = 0; i < animals_count(); ++i) {
+        const Reptile *r = animals_get_by_index(i);
+        if (!r) continue;
+        const char *status = (legal_is_cerfa_valid(r) && legal_is_cites_valid(r)) ?
+                                ui_get_text(TXT_LEGAL_OK) : ui_get_text(TXT_LEGAL_EXPIRED);
+        lv_obj_t *btn = lv_list_add_btn(list, NULL, r->name);
+        lv_obj_t *lbl = lv_label_create(btn);
+        lv_label_set_text(lbl, status);
+        lv_obj_align(lbl, LV_ALIGN_RIGHT_MID, -10, 0);
+    }
+}
+
+static void terrariums_tab_create(lv_obj_t *tab)
+{
+    lv_obj_t *list = lv_list_create(tab);
+    lv_obj_set_size(list, 380, 420);
+    for (int i = 0; i < terrariums_count_for_elevage(0); ++i) {
+        const Terrarium *t = terrariums_get_by_index_for_elevage(i, 0);
+        if (!t) continue;
+        char buf[64];
+        snprintf(buf, sizeof(buf), "%s (%d)", t->name, t->capacity);
+        lv_list_add_btn(list, NULL, buf);
+    }
+}
+
+static void stocks_tab_create(lv_obj_t *tab)
+{
+    lv_obj_t *list = lv_list_create(tab);
+    lv_obj_set_size(list, 380, 420);
+    for (int i = 0; i < stocks_count(); ++i) {
+        const StockItem *s = stocks_get_by_index(i);
+        if (!s) continue;
+        char buf[64];
+        snprintf(buf, sizeof(buf), "%s (%d)", s->name, s->quantity);
+        lv_list_add_btn(list, NULL, buf);
+    }
+}
+
+static void transactions_tab_create(lv_obj_t *tab)
+{
+    lv_obj_t *list = lv_list_create(tab);
+    lv_obj_set_size(list, 380, 420);
+    for (int i = 0; i < transactions_count(); ++i) {
+        const Transaction *tr = transactions_get_by_index(i);
+        if (!tr) continue;
+        char buf[64];
+        snprintf(buf, sizeof(buf), "%d %s %d", tr->stock_id,
+                 tr->type == TRANSACTION_PURCHASE ? "+" : "-",
+                 tr->quantity);
+        lv_list_add_btn(list, NULL, buf);
+    }
+}
+
+static void export_event(lv_event_t *e)
+{
+    storage_export_csv("/sdcard/export.csv");
+    ui_notify("Export OK");
+}
+
+static void import_event(lv_event_t *e)
+{
+    storage_restore();
+    ui_notify("Import OK");
+}
+
+static void lang_event(lv_event_t *e)
+{
+    uint32_t sel = lv_dropdown_get_selected(lv_event_get_target(e));
+    ui_set_language(sel == 0 ? UI_LANG_EN : UI_LANG_FR);
+}
+
+static void theme_event(lv_event_t *e)
+{
+    uint32_t sel = lv_dropdown_get_selected(lv_event_get_target(e));
+    ui_set_theme(sel == 0 ? UI_THEME_LIGHT : UI_THEME_DARK);
+}
+
+static void settings_tab_create(lv_obj_t *tab)
+{
+    lv_obj_t *dd_lang = lv_dropdown_create(tab);
+    lv_dropdown_set_options(dd_lang, "English\nFrancais");
+    lv_obj_add_event_cb(dd_lang, lang_event, LV_EVENT_VALUE_CHANGED, NULL);
+
+    lv_obj_t *dd_theme = lv_dropdown_create(tab);
+    lv_obj_align(dd_theme, LV_ALIGN_TOP_MID, 0, 40);
+    lv_dropdown_set_options(dd_theme, "Light\nDark");
+    lv_obj_add_event_cb(dd_theme, theme_event, LV_EVENT_VALUE_CHANGED, NULL);
+
+    lv_obj_t *btn_export = lv_btn_create(tab);
+    lv_obj_align(btn_export, LV_ALIGN_BOTTOM_LEFT, 10, -10);
+    lv_obj_add_event_cb(btn_export, export_event, LV_EVENT_CLICKED, NULL);
+    lv_obj_t *lbl1 = lv_label_create(btn_export);
+    lv_label_set_text(lbl1, ui_get_text(TXT_EXPORT));
+
+    lv_obj_t *btn_import = lv_btn_create(tab);
+    lv_obj_align(btn_import, LV_ALIGN_BOTTOM_RIGHT, -10, -10);
+    lv_obj_add_event_cb(btn_import, import_event, LV_EVENT_CLICKED, NULL);
+    lv_obj_t *lbl2 = lv_label_create(btn_import);
+    lv_label_set_text(lbl2, ui_get_text(TXT_IMPORT));
+}
 
 const char *ui_get_text(ui_text_id_t id)
 {
@@ -37,7 +164,9 @@ void ui_set_language(ui_language_t lang)
     if (tabview) {
         lv_tabview_set_tab_name(tabview, 0, ui_get_text(TXT_ANIMALS));
         lv_tabview_set_tab_name(tabview, 1, ui_get_text(TXT_TERRARIUMS));
-        lv_tabview_set_tab_name(tabview, 2, ui_get_text(TXT_SETTINGS));
+        lv_tabview_set_tab_name(tabview, 2, ui_get_text(TXT_STOCKS));
+        lv_tabview_set_tab_name(tabview, 3, ui_get_text(TXT_TRANSACTIONS));
+        lv_tabview_set_tab_name(tabview, 4, ui_get_text(TXT_SETTINGS));
     }
 }
 
@@ -73,16 +202,15 @@ void ui_init(ui_language_t lang, ui_theme_t theme)
 
     lv_obj_t *tab1 = lv_tabview_add_tab(tabview, ui_get_text(TXT_ANIMALS));
     lv_obj_t *tab2 = lv_tabview_add_tab(tabview, ui_get_text(TXT_TERRARIUMS));
-    lv_obj_t *tab3 = lv_tabview_add_tab(tabview, ui_get_text(TXT_SETTINGS));
+    lv_obj_t *tab3 = lv_tabview_add_tab(tabview, ui_get_text(TXT_STOCKS));
+    lv_obj_t *tab4 = lv_tabview_add_tab(tabview, ui_get_text(TXT_TRANSACTIONS));
+    lv_obj_t *tab5 = lv_tabview_add_tab(tabview, ui_get_text(TXT_SETTINGS));
 
-    lv_label_create(tab1);
-    lv_label_set_text(lv_obj_get_child(tab1, 0), ui_get_text(TXT_ANIMALS));
-
-    lv_label_create(tab2);
-    lv_label_set_text(lv_obj_get_child(tab2, 0), ui_get_text(TXT_TERRARIUMS));
-
-    lv_label_create(tab3);
-    lv_label_set_text(lv_obj_get_child(tab3, 0), ui_get_text(TXT_SETTINGS));
+    animals_tab_create(tab1);
+    terrariums_tab_create(tab2);
+    stocks_tab_create(tab3);
+    transactions_tab_create(tab4);
+    settings_tab_create(tab5);
 
     notif_label = lv_label_create(lv_scr_act());
     lv_obj_align(notif_label, LV_ALIGN_BOTTOM_MID, 0, -10);

--- a/components/ui/ui.h
+++ b/components/ui/ui.h
@@ -27,7 +27,15 @@ typedef enum {
 typedef enum {
     TXT_ANIMALS,
     TXT_TERRARIUMS,
+    TXT_STOCKS,
+    TXT_TRANSACTIONS,
     TXT_SETTINGS,
+    TXT_EXPORT,
+    TXT_IMPORT,
+    TXT_LEGAL_OK,
+    TXT_LEGAL_EXPIRED,
+    TXT_LANGUAGE,
+    TXT_THEME,
     TXT_COUNT
 } ui_text_id_t;
 

--- a/docs/UI_USAGE.md
+++ b/docs/UI_USAGE.md
@@ -19,3 +19,11 @@ ui_set_theme(UI_THEME_DARK);
 ```
 
 Les textes des onglets sont mis à jour automatiquement selon la langue sélectionnée.
+
+## Onglets disponibles
+
+- **Animaux** : liste les reptiles avec l'état de leurs documents légaux.
+- **Terrariums** : affiche les terrariums disponibles.
+- **Stocks** : permet de consulter le matériel ou la nourriture en stock.
+- **Transactions** : liste les mouvements de stock.
+- **Paramètres** : choix de la langue et du thème, export et import des données.


### PR DESCRIPTION
## Summary
- show lists for animals, terrariums, stock and transactions
- add language and theme selection in settings
- provide export/import actions
- expose transaction list helpers
- update docs

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fdb407b088323a7d0bbf0b5a42f28