### PR TITLE
Switch modules to SQLite persistence

### DIFF
--- a/components/animals/animals.c
+++ b/components/animals/animals.c
@@ -1,5 +1,7 @@
 #include "animals.h"
 #include "esp_log.h"
+#include "db.h"
+#include <sqlite3.h>
 #include <string.h>
 
 static const char *TAG = "animals";
@@ -11,12 +13,41 @@ void animals_init(void)
 {
     animal_count = 0;
     memset(animals, 0, sizeof(animals));
+
+    sqlite3_stmt *stmt = db_query("SELECT id,elevage_id,name,species,sex,birth_date,health,breeding_cycle FROM animals;");
+    if (stmt) {
+        while (sqlite3_step(stmt) == SQLITE_ROW && animal_count < ANIMALS_MAX) {
+            Reptile *r = &animals[animal_count++];
+            r->id = sqlite3_column_int(stmt, 0);
+            r->elevage_id = sqlite3_column_int(stmt, 1);
+            strncpy(r->name, (const char *)sqlite3_column_text(stmt, 2), sizeof(r->name) - 1);
+            strncpy(r->species, (const char *)sqlite3_column_text(stmt, 3), sizeof(r->species) - 1);
+            strncpy(r->sex, (const char *)sqlite3_column_text(stmt, 4), sizeof(r->sex) - 1);
+            strncpy(r->birth_date, (const char *)sqlite3_column_text(stmt, 5), sizeof(r->birth_date) - 1);
+            strncpy(r->health, (const char *)sqlite3_column_text(stmt, 6), sizeof(r->health) - 1);
+            strncpy(r->breeding_cycle, (const char *)sqlite3_column_text(stmt, 7), sizeof(r->breeding_cycle) - 1);
+            r->cdc_number[0] = '\0';
+            r->aoe_number[0] = '\0';
+            r->ifap_id[0] = '\0';
+            r->quota_limit = 0;
+            r->quota_used = 0;
+            r->cerfa_valid_until = 0;
+            r->cites_valid_until = 0;
+        }
+        sqlite3_finalize(stmt);
+    }
+
     ESP_LOGI(TAG, "Initialisation des donnees animaux");
 }
 
 bool animals_add(const Reptile *r)
 {
     if (animal_count >= ANIMALS_MAX || !r)
+        return false;
+    if (!db_exec("INSERT INTO animals(id,elevage_id,name,species,sex,birth_date,health,breeding_cycle) "
+                 "VALUES(%d,%d,'%s','%s','%s','%s','%s','%s');",
+                 r->id, r->elevage_id, r->name, r->species, r->sex, r->birth_date,
+                 r->health, r->breeding_cycle))
         return false;
     animals[animal_count] = *r;
     animal_count++;
@@ -46,6 +77,11 @@ bool animals_update(int id, const Reptile *r)
     int idx = find_index(id);
     if (idx < 0 || !r)
         return false;
+    if (!db_exec("UPDATE animals SET elevage_id=%d,name='%s',species='%s',sex='%s'," 
+                 "birth_date='%s',health='%s',breeding_cycle='%s' WHERE id=%d;",
+                 r->elevage_id, r->name, r->species, r->sex, r->birth_date,
+                 r->health, r->breeding_cycle, id))
+        return false;
     animals[idx] = *r;
     ESP_LOGI(TAG, "Mise a jour du reptile %d", id);
     return true;
@@ -55,6 +91,8 @@ bool animals_delete(int id)
 {
     int idx = find_index(id);
     if (idx < 0)
+        return false;
+    if (!db_exec("DELETE FROM animals WHERE id=%d;", id))
         return false;
     for (int i = idx; i < animal_count - 1; ++i) {
         animals[i] = animals[i + 1];

--- a/components/db/db.c
+++ b/components/db/db.c
@@ -4,6 +4,7 @@
 #include <sqlite3.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdarg.h>
 
 static const char *TAG = "db";
 static sqlite3 *db_handle = NULL;
@@ -15,6 +16,39 @@ static void exec_simple(const char *sql)
         ESP_LOGE(TAG, "SQL error: %s", err ? err : "unknown");
         sqlite3_free(err);
     }
+}
+
+bool db_exec(const char *format, ...)
+{
+    char sql[256];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(sql, sizeof(sql), format, args);
+    va_end(args);
+
+    char *err = NULL;
+    if (sqlite3_exec(db_handle, sql, NULL, NULL, &err) != SQLITE_OK) {
+        ESP_LOGE(TAG, "SQL exec error: %s", err ? err : "unknown");
+        sqlite3_free(err);
+        return false;
+    }
+    return true;
+}
+
+sqlite3_stmt *db_query(const char *format, ...)
+{
+    char sql[256];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(sql, sizeof(sql), format, args);
+    va_end(args);
+
+    sqlite3_stmt *stmt = NULL;
+    if (sqlite3_prepare_v2(db_handle, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        ESP_LOGE(TAG, "SQL query error: %s", sqlite3_errmsg(db_handle));
+        return NULL;
+    }
+    return stmt;
 }
 
 void db_init(void)

--- a/components/db/db.h
+++ b/components/db/db.h
@@ -1,6 +1,8 @@
 #ifndef DB_H
 #define DB_H
 
+#include <sqlite3.h>
+
 /**
  * \brief Initialise la base de données locale.
  */
@@ -24,5 +26,15 @@ void db_export_csv(const char *path);
  * \param path Chemin du fichier de destination.
  */
 void db_export_json(const char *path);
+
+/**
+ * \brief Execute une requete SQL sans retour de resultats.
+ */
+bool db_exec(const char *format, ...);
+
+/**
+ * \brief Prepare une requete SELECT et renvoie l'objet sqlite3_stmt.
+ */
+sqlite3_stmt *db_query(const char *format, ...);
 
 #endif // DB_H

--- a/components/stocks/stocks.c
+++ b/components/stocks/stocks.c
@@ -1,5 +1,7 @@
 #include "stocks.h"
 #include "esp_log.h"
+#include "db.h"
+#include <sqlite3.h>
 #include <string.h>
 
 static const char *TAG = "stocks";
@@ -11,6 +13,19 @@ void stocks_init(void)
 {
     stock_count = 0;
     memset(stock_items, 0, sizeof(stock_items));
+
+    sqlite3_stmt *stmt = db_query("SELECT id,name,quantity,min_quantity FROM stocks;");
+    if (stmt) {
+        while (sqlite3_step(stmt) == SQLITE_ROW && stock_count < STOCKS_MAX) {
+            StockItem *s = &stock_items[stock_count++];
+            s->id = sqlite3_column_int(stmt, 0);
+            strncpy(s->name, (const char *)sqlite3_column_text(stmt, 1), sizeof(s->name) - 1);
+            s->quantity = sqlite3_column_int(stmt, 2);
+            s->min_quantity = sqlite3_column_int(stmt, 3);
+        }
+        sqlite3_finalize(stmt);
+    }
+
     ESP_LOGI(TAG, "Initialisation des stocks");
 }
 
@@ -26,6 +41,9 @@ static int find_index(int id)
 bool stocks_add(const StockItem *item)
 {
     if (stock_count >= STOCKS_MAX || !item)
+        return false;
+    if (!db_exec("INSERT INTO stocks(id,name,quantity,min_quantity) VALUES(%d,'%s',%d,%d);",
+                 item->id, item->name, item->quantity, item->min_quantity))
         return false;
     stock_items[stock_count] = *item;
     stock_count++;
@@ -46,6 +64,9 @@ bool stocks_update(int id, const StockItem *item)
     int idx = find_index(id);
     if (idx < 0 || !item)
         return false;
+    if (!db_exec("UPDATE stocks SET name='%s',quantity=%d,min_quantity=%d WHERE id=%d;",
+                 item->name, item->quantity, item->min_quantity, id))
+        return false;
     stock_items[idx] = *item;
     ESP_LOGI(TAG, "Mise a jour de l'article %d", id);
     return true;
@@ -55,6 +76,8 @@ bool stocks_delete(int id)
 {
     int idx = find_index(id);
     if (idx < 0)
+        return false;
+    if (!db_exec("DELETE FROM stocks WHERE id=%d;", id))
         return false;
     for (int i = idx; i < stock_count - 1; ++i) {
         stock_items[i] = stock_items[i + 1];

--- a/components/terrariums/terrariums.c
+++ b/components/terrariums/terrariums.c
@@ -1,5 +1,7 @@
 #include "terrariums.h"
 #include "esp_log.h"
+#include "db.h"
+#include <sqlite3.h>
 #include <string.h>
 
 static const char *TAG = "terrariums";
@@ -14,12 +16,31 @@ void terrariums_init(void)
     terrarium_count = 0;
     log_count = 0;
     memset(terrariums, 0, sizeof(terrariums));
+
+    sqlite3_stmt *stmt = db_query("SELECT id,elevage_id,name,capacity,inventory,notes FROM terrariums;");
+    if (stmt) {
+        while (sqlite3_step(stmt) == SQLITE_ROW && terrarium_count < TERRARIUMS_MAX) {
+            Terrarium *t = &terrariums[terrarium_count++];
+            t->id = sqlite3_column_int(stmt, 0);
+            t->elevage_id = sqlite3_column_int(stmt, 1);
+            strncpy(t->name, (const char *)sqlite3_column_text(stmt, 2), sizeof(t->name) - 1);
+            t->capacity = sqlite3_column_int(stmt, 3);
+            strncpy(t->inventory, (const char *)sqlite3_column_text(stmt, 4), sizeof(t->inventory) - 1);
+            strncpy(t->notes, (const char *)sqlite3_column_text(stmt, 5), sizeof(t->notes) - 1);
+        }
+        sqlite3_finalize(stmt);
+    }
+
     ESP_LOGI(TAG, "Initialisation des terrariums");
 }
 
 bool terrariums_add(const Terrarium *t)
 {
     if (terrarium_count >= TERRARIUMS_MAX || !t)
+        return false;
+    if (!db_exec("INSERT INTO terrariums(id,elevage_id,name,capacity,inventory,notes) "
+                 "VALUES(%d,%d,'%s',%d,'%s','%s');",
+                 t->id, t->elevage_id, t->name, t->capacity, t->inventory, t->notes))
         return false;
     terrariums[terrarium_count] = *t;
     terrarium_count++;
@@ -49,6 +70,9 @@ bool terrariums_update(int id, const Terrarium *t)
     int idx = find_index(id);
     if (idx < 0 || !t)
         return false;
+    if (!db_exec("UPDATE terrariums SET elevage_id=%d,name='%s',capacity=%d,inventory='%s',notes='%s' WHERE id=%d;",
+                 t->elevage_id, t->name, t->capacity, t->inventory, t->notes, id))
+        return false;
     terrariums[idx] = *t;
     ESP_LOGI(TAG, "Mise a jour du terrarium %d", id);
     return true;
@@ -58,6 +82,8 @@ bool terrariums_delete(int id)
 {
     int idx = find_index(id);
     if (idx < 0)
+        return false;
+    if (!db_exec("DELETE FROM terrariums WHERE id=%d;", id))
         return false;
     for (int i = idx; i < terrarium_count - 1; ++i) {
         terrariums[i] = terrariums[i + 1];
@@ -71,6 +97,7 @@ void terrariums_log_transaction(const char *msg)
 {
     if (log_count >= LOGS_MAX || !msg)
         return;
+    db_exec("INSERT INTO terrarium_logs(message,terrarium_id) VALUES('%s',0);", msg);
     strncpy(logs[log_count], msg, sizeof(logs[0]) - 1);
     logs[log_count][sizeof(logs[0]) - 1] = '\0';
     ESP_LOGI(TAG, "Log: %s", logs[log_count]);

--- a/components/transactions/transactions.c
+++ b/components/transactions/transactions.c
@@ -1,5 +1,7 @@
 #include "transactions.h"
 #include "esp_log.h"
+#include "db.h"
+#include <sqlite3.h>
 #include <string.h>
 
 static const char *TAG = "transactions";
@@ -11,6 +13,20 @@ void transactions_init(void)
 {
     transaction_count = 0;
     memset(transactions, 0, sizeof(transactions));
+
+    sqlite3_stmt *stmt = db_query("SELECT id,stock_id,quantity,type FROM transactions;");
+    if (stmt) {
+        while (sqlite3_step(stmt) == SQLITE_ROW && transaction_count < TRANSACTIONS_MAX) {
+            Transaction *tr = &transactions[transaction_count++];
+            tr->id = sqlite3_column_int(stmt, 0);
+            tr->stock_id = sqlite3_column_int(stmt, 1);
+            tr->quantity = sqlite3_column_int(stmt, 2);
+            const char *type = (const char *)sqlite3_column_text(stmt, 3);
+            tr->type = (type && strcmp(type, "SALE") == 0) ? TRANSACTION_SALE : TRANSACTION_PURCHASE;
+        }
+        sqlite3_finalize(stmt);
+    }
+
     ESP_LOGI(TAG, "Initialisation des transactions");
 }
 
@@ -26,6 +42,10 @@ static int find_index(int id)
 bool transactions_add(const Transaction *t)
 {
     if (transaction_count >= TRANSACTIONS_MAX || !t)
+        return false;
+    const char *type = t->type == TRANSACTION_SALE ? "SALE" : "PURCHASE";
+    if (!db_exec("INSERT INTO transactions(id,stock_id,quantity,type) VALUES(%d,%d,%d,'%s');",
+                 t->id, t->stock_id, t->quantity, type))
         return false;
     transactions[transaction_count] = *t;
     transaction_count++;
@@ -46,6 +66,10 @@ bool transactions_update(int id, const Transaction *t)
     int idx = find_index(id);
     if (idx < 0 || !t)
         return false;
+    const char *type = t->type == TRANSACTION_SALE ? "SALE" : "PURCHASE";
+    if (!db_exec("UPDATE transactions SET stock_id=%d,quantity=%d,type='%s' WHERE id=%d;",
+                 t->stock_id, t->quantity, type, id))
+        return false;
     transactions[idx] = *t;
     ESP_LOGI(TAG, "Mise a jour de la transaction %d", id);
     return true;
@@ -55,6 +79,8 @@ bool transactions_delete(int id)
 {
     int idx = find_index(id);
     if (idx < 0)
+        return false;
+    if (!db_exec("DELETE FROM transactions WHERE id=%d;", id))
         return false;
     for (int i = idx; i < transaction_count - 1; ++i) {
         transactions[i] = transactions[i + 1];


### PR DESCRIPTION
## Summary
- add `db_exec` and `db_query` helpers
- load data from the database in every module
- persist CRUD operations for animals, terrariums, stocks and transactions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685fdfab33e4832388435cff4facaccf