### PR TITLE
Add IV and configurable AES key

### DIFF
--- a/components/storage/storage.c
+++ b/components/storage/storage.c
@@ -4,6 +4,9 @@
 #include "esp_vfs_fat.h"
 #include "sdmmc_cmd.h"
 #include "mbedtls/aes.h"
+#include "nvs.h"
+#include "nvs_flash.h"
+#include "esp_system.h"
 #include "db.h"
 #include "legal.h"
 #include "esp_http_client.h"
@@ -12,7 +15,36 @@
 #include <stdio.h>
 
 static const char *TAG = "storage";
-static const unsigned char aes_key[16] = "lizard-secret!!";
+static unsigned char aes_key[16];
+
+static void load_aes_key(void)
+{
+    nvs_handle_t h;
+    size_t len = sizeof(aes_key);
+    if (nvs_open("storage", NVS_READONLY, &h) == ESP_OK) {
+        if (nvs_get_blob(h, "aes_key", aes_key, &len) != ESP_OK || len != sizeof(aes_key)) {
+            memset(aes_key, 0, sizeof(aes_key));
+        }
+        nvs_close(h);
+    } else {
+        memset(aes_key, 0, sizeof(aes_key));
+    }
+}
+
+bool storage_set_aes_key(const unsigned char key[16])
+{
+    memcpy(aes_key, key, 16);
+    nvs_handle_t h;
+    if (nvs_open("storage", NVS_READWRITE, &h) != ESP_OK) {
+        return false;
+    }
+    esp_err_t err = nvs_set_blob(h, "aes_key", key, 16);
+    if (err == ESP_OK) {
+        err = nvs_commit(h);
+    }
+    nvs_close(h);
+    return err == ESP_OK;
+}
 
 bool storage_encrypt_file(const char *path)
 {
@@ -37,7 +69,8 @@ bool storage_encrypt_file(const char *path)
     mbedtls_aes_context ctx;
     mbedtls_aes_init(&ctx);
     mbedtls_aes_setkey_enc(&ctx, aes_key, 128);
-    unsigned char iv[16] = {0};
+    unsigned char iv[16];
+    esp_fill_random(iv, sizeof(iv));
     mbedtls_aes_crypt_cbc(&ctx, MBEDTLS_AES_ENCRYPT, padded_len, iv, buf, buf);
     mbedtls_aes_free(&ctx);
 
@@ -49,6 +82,7 @@ bool storage_encrypt_file(const char *path)
 
     uint32_t orig_len = (uint32_t)len;
     fwrite(&orig_len, 1, sizeof(orig_len), f);
+    fwrite(iv, 1, sizeof(iv), f);
     fwrite(buf, 1, padded_len, f);
     fclose(f);
     free(buf);
@@ -67,10 +101,16 @@ bool storage_decrypt_file(const char *src, const char *dst)
         return false;
     }
 
+    unsigned char iv[16];
+    if (fread(iv, 1, sizeof(iv), f) != sizeof(iv)) {
+        fclose(f);
+        return false;
+    }
+
     fseek(f, 0, SEEK_END);
     long file_len = ftell(f);
-    long enc_len = file_len - sizeof(orig_len);
-    fseek(f, sizeof(orig_len), SEEK_SET);
+    long enc_len = file_len - sizeof(orig_len) - sizeof(iv);
+    fseek(f, sizeof(orig_len) + sizeof(iv), SEEK_SET);
 
     unsigned char *buf = malloc(enc_len);
     if (!buf) {
@@ -84,7 +124,6 @@ bool storage_decrypt_file(const char *src, const char *dst)
     mbedtls_aes_context ctx;
     mbedtls_aes_init(&ctx);
     mbedtls_aes_setkey_dec(&ctx, aes_key, 128);
-    unsigned char iv[16] = {0};
     mbedtls_aes_crypt_cbc(&ctx, MBEDTLS_AES_DECRYPT, enc_len, iv, buf, buf);
     mbedtls_aes_free(&ctx);
 
@@ -125,6 +164,7 @@ bool storage_mount_sdcard(void)
 void storage_init(void)
 {
     ESP_LOGI(TAG, "Initialisation du stockage externe");
+    load_aes_key();
     storage_mount_sdcard();
 }
 

--- a/components/storage/storage.h
+++ b/components/storage/storage.h
@@ -5,7 +5,7 @@
 #include "animals.h"
 
 /**
- * \brief Initialise et monte le stockage externe (SD, SPIFFS...).
+ * \brief Initialise le stockage externe et charge la cle AES.
  */
 void storage_init(void);
 
@@ -52,5 +52,12 @@ bool storage_encrypt_file(const char *path);
  * \param dst Fichier de sortie dechiffre.
  */
 bool storage_decrypt_file(const char *src, const char *dst);
+
+/**
+ * \brief Definit la cle AES utilisee pour le chiffrement.
+ * \param key Tableau de 16 octets.
+ * \return true si la cle a ete enregistree.
+ */
+bool storage_set_aes_key(const unsigned char key[16]);
 
 #endif // STORAGE_H

--- a/docs/ENCRYPTION_FORMAT.md
+++ b/docs/ENCRYPTION_FORMAT.md
@@ -1,0 +1,22 @@
+# Format de chiffrement des fichiers
+
+Les fichiers produits par `storage_encrypt_file` commencent par un en‑tête
+permettant à `storage_decrypt_file` de récupérer les informations nécessaires
+au déchiffrement.
+
+```
++-----------+--------------------+----------------------+
+| 4 octets  | 16 octets          | Données chiffrées    |
+| longueur  | vecteur d'initial. | AES-CBC (paddée)     |
++-----------+--------------------+----------------------+
+```
+
+- **longueur** : taille originale du fichier avant chiffrement, little‑endian.
+- **vecteur d'initialisation** : IV aléatoire généré pour chaque fichier.
+- **données chiffrées** : contenu du fichier chiffré en AES‑128‑CBC et
+  aligné sur 16 octets par bourrage nul.
+
+La clé AES de 128 bits n'est pas stockée dans le fichier. Elle doit être
+récupérée dans l'espace NVS "storage" sous la clé `aes_key`. Elle peut être
+initialisée ou mise à jour via `storage_set_aes_key()`.
+


### PR DESCRIPTION
## Summary
- generate a random IV for every encryption
- load/save AES key from NVS and allow user configuration
- document encrypted file structure

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe18e9e7483238137e1176105f257