### PR TITLE
Add HTTP file transfer with esp_http_client

### DIFF
--- a/components/storage/storage.c
+++ b/components/storage/storage.c
@@ -185,13 +185,67 @@ void storage_export_pdf(const char *dir, const Reptile *r)
 bool storage_wifi_transfer(const char *path, const char *url)
 {
     ESP_LOGI(TAG, "Transfert Wi-Fi de %s vers %s", path, url);
+
     FILE *f = fopen(path, "rb");
     if (!f) {
         ESP_LOGE(TAG, "Fichier %s introuvable", path);
         return false;
     }
+
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    unsigned char *buf = malloc(len);
+    if (!buf) {
+        fclose(f);
+        ESP_LOGE(TAG, "Memoire insuffisante");
+        return false;
+    }
+
+    if (fread(buf, 1, len, f) != (size_t)len) {
+        ESP_LOGE(TAG, "Lecture du fichier echouee");
+        fclose(f);
+        free(buf);
+        return false;
+    }
     fclose(f);
-    // Simulation d'envoi HTTP; a implementer reellement avec esp_http_client
+
+    esp_http_client_config_t cfg = {
+        .url = url,
+        .method = HTTP_METHOD_POST,
+#ifdef CONFIG_STORAGE_TRANSFER_USERNAME
+        .username = CONFIG_STORAGE_TRANSFER_USERNAME,
+#endif
+#ifdef CONFIG_STORAGE_TRANSFER_PASSWORD
+        .password = CONFIG_STORAGE_TRANSFER_PASSWORD,
+#endif
+    };
+
+    esp_http_client_handle_t client = esp_http_client_init(&cfg);
+    if (!client) {
+        ESP_LOGE(TAG, "Initialisation client HTTP echouee");
+        free(buf);
+        return false;
+    }
+
+    esp_http_client_set_header(client, "Content-Type", "application/octet-stream");
+    esp_http_client_set_post_field(client, (const char *)buf, len);
+    esp_err_t err = esp_http_client_perform(client);
+    int status = esp_http_client_get_status_code(client);
+    esp_http_client_cleanup(client);
+    free(buf);
+
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Erreur HTTP: %s", esp_err_to_name(err));
+        return false;
+    }
+
+    if (status >= 400) {
+        ESP_LOGE(TAG, "Serveur a repondu statut %d", status);
+        return false;
+    }
+
     ESP_LOGI(TAG, "Transfert termine");
     return true;
 }

--- a/docs/CONFIG_EXAMPLE.md
+++ b/docs/CONFIG_EXAMPLE.md
@@ -5,6 +5,8 @@ CONFIG_WIFI_SSID="VotreSSID"
 CONFIG_WIFI_PASSWORD="VotreMotDePasse"
 CONFIG_STORAGE_MOUNT_POINT="/sdcard"
 CONFIG_STORAGE_TRANSFER_URL="http://example.com/upload"
+CONFIG_STORAGE_TRANSFER_USERNAME="user"
+CONFIG_STORAGE_TRANSFER_PASSWORD="secret"
 CONFIG_DRIVERS_REST_URL="http://example.com/sensors"
 CONFIG_DRIVERS_MQTT_URI="mqtt://broker"
 CONFIG_DRIVERS_MQTT_TOPIC="/lizard/data"
@@ -12,3 +14,6 @@ CONFIG_DB_DEFAULT_KEY="MonMotDePasseBD"
 ```
 
 Ce fichier illustre comment définir certaines options via `sdkconfig`.
+`CONFIG_STORAGE_TRANSFER_URL` indique l'endpoint HTTP pour l'envoi de fichiers.
+Si le serveur requiert une authentification basique, renseignez
+`CONFIG_STORAGE_TRANSFER_USERNAME` et `CONFIG_STORAGE_TRANSFER_PASSWORD`.


### PR DESCRIPTION
## Summary
- implement `storage_wifi_transfer` using `esp_http_client` for file uploads
- document transfer URL and credentials in CONFIG_EXAMPLE

## Testing
- `make --version | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_685fe6ff0d048323b393efe35f1c4e80