### PR TITLE
Add elevages module and user links

### DIFF
--- a/components/auth/auth.c
+++ b/components/auth/auth.c
@@ -22,6 +22,7 @@ void auth_init(void)
     ESP_LOGI(TAG, "Initialisation du module d'authentification");
     user_count = 0;
     auth_add_user("admin", "changeme", ROLE_PARTICULIER);
+    auth_link_elevage("admin", 0);
 }
 
 bool auth_add_user(const char *username, const char *password, user_role_t role)
@@ -32,6 +33,7 @@ bool auth_add_user(const char *username, const char *password, user_role_t role)
     users[user_count].username[sizeof(users[user_count].username) - 1] = '\0';
     sha256_hash(password, users[user_count].hash);
     users[user_count].role = role;
+    users[user_count].elevage_count = 0;
     user_count++;
     return true;
 }
@@ -55,4 +57,37 @@ user_role_t auth_get_role(const char *username)
             return users[i].role;
     }
     return ROLE_PARTICULIER;
+}
+
+bool auth_link_elevage(const char *username, int elevage_id)
+{
+    for (int i = 0; i < user_count; ++i) {
+        if (strcmp(users[i].username, username) == 0) {
+            if (users[i].elevage_count >= AUTH_MAX_ELEVAGES_PER_USER)
+                return false;
+            users[i].elevages[users[i].elevage_count++] = elevage_id;
+            return true;
+        }
+    }
+    return false;
+}
+
+int auth_get_elevage_count(const char *username)
+{
+    for (int i = 0; i < user_count; ++i) {
+        if (strcmp(users[i].username, username) == 0)
+            return users[i].elevage_count;
+    }
+    return 0;
+}
+
+int auth_get_elevage_by_index(const char *username, int index)
+{
+    for (int i = 0; i < user_count; ++i) {
+        if (strcmp(users[i].username, username) == 0) {
+            if (index >= 0 && index < users[i].elevage_count)
+                return users[i].elevages[index];
+        }
+    }
+    return -1;
 }

--- a/components/auth/auth.h
+++ b/components/auth/auth.h
@@ -12,11 +12,14 @@ typedef enum {
 } user_role_t;
 
 #define AUTH_MAX_USERS 5
+#define AUTH_MAX_ELEVAGES_PER_USER 5
 
 typedef struct {
     char username[32];
     unsigned char hash[32];
     user_role_t role;
+    int elevages[AUTH_MAX_ELEVAGES_PER_USER];
+    int elevage_count;
 } auth_user_t;
 
 /**
@@ -38,5 +41,9 @@ bool auth_check(const char *username, const char *password);
  * \brief Récupère le rôle d'un utilisateur.
  */
 user_role_t auth_get_role(const char *username);
+
+bool auth_link_elevage(const char *username, int elevage_id);
+int auth_get_elevage_count(const char *username);
+int auth_get_elevage_by_index(const char *username, int index);
 
 #endif // AUTH_H

--- a/components/db/db.c
+++ b/components/db/db.c
@@ -117,6 +117,11 @@ void db_init(void)
     }
 #endif
 
+    exec_simple("CREATE TABLE IF NOT EXISTS elevages(""
+                "id INTEGER PRIMARY KEY,""
+                "name TEXT,""
+                "description TEXT);");
+
     exec_simple("CREATE TABLE IF NOT EXISTS animals("
                 "id INTEGER PRIMARY KEY,"
                 "elevage_id INTEGER,"
@@ -175,6 +180,26 @@ void db_backup(void)
     }
     sqlite3_close(backup_db);
     storage_encrypt_file("/sdcard/lizard_backup.db");
+}
+
+static void export_elevages_csv(FILE *f)
+{
+    fprintf(f, "elevages\n");
+    fprintf(f, "id,name,description\n");
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(db_handle,
+                           "SELECT id,name,description FROM elevages;",
+                           -1, &stmt, NULL) == SQLITE_OK) {
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            fprintf(f, "%d,%s,%s\n",
+                    sqlite3_column_int(stmt, 0),
+                    sqlite3_column_text(stmt, 1),
+                    sqlite3_column_text(stmt, 2));
+        }
+        sqlite3_finalize(stmt);
+    }
+    fprintf(f, "\n");
 }
 
 static void export_animals_csv(FILE *f)
@@ -268,6 +293,27 @@ static void export_transactions_csv(FILE *f)
     fprintf(f, "\n");
 }
 
+static void export_elevages_json(FILE *f)
+{
+    fprintf(f, "  \"elevages\": [\n");
+    sqlite3_stmt *stmt;
+    bool first = true;
+    if (sqlite3_prepare_v2(db_handle,
+                           "SELECT id,name,description FROM elevages;",
+                           -1, &stmt, NULL) == SQLITE_OK) {
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            if (!first) fprintf(f, ",\n");
+            first = false;
+            fprintf(f, "    {\"id\":%d,\"name\":\"%s\",\"description\":\"%s\"}",
+                    sqlite3_column_int(stmt, 0),
+                    sqlite3_column_text(stmt, 1),
+                    sqlite3_column_text(stmt, 2));
+        }
+        sqlite3_finalize(stmt);
+    }
+    fprintf(f, "\n  ],\n");
+}
+
 void db_export_csv(const char *path)
 {
     if (!db_handle || !path)
@@ -279,6 +325,7 @@ void db_export_csv(const char *path)
         return;
     }
 
+    export_elevages_csv(f);
     export_animals_csv(f);
     export_terrariums_csv(f);
     export_stocks_csv(f);
@@ -395,6 +442,8 @@ void db_export_json(const char *path)
     }
 
     fprintf(f, "{\n");
+    export_elevages_json(f);
+    fprintf(f, ",\n");
     export_animals_json(f);
     fprintf(f, ",\n");
     export_terrariums_json(f);

--- a/components/elevages/CMakeLists.txt
+++ b/components/elevages/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "elevages.c" \
+                       INCLUDE_DIRS ".")

--- a/components/elevages/elevages.c
+++ b/components/elevages/elevages.c
@@ -1,0 +1,99 @@
+#include "elevages.h"
+#include "esp_log.h"
+#include "db.h"
+#include <sqlite3.h>
+#include <string.h>
+
+static const char *TAG = "elevages";
+
+static Elevage elevages[ELEVAGES_MAX];
+static int elevage_count = 0;
+
+void elevages_init(void)
+{
+    elevage_count = 0;
+    memset(elevages, 0, sizeof(elevages));
+
+    sqlite3_stmt *stmt = db_query("SELECT id,name,description FROM elevages;");
+    if (stmt) {
+        while (sqlite3_step(stmt) == SQLITE_ROW && elevage_count < ELEVAGES_MAX) {
+            Elevage *e = &elevages[elevage_count++];
+            e->id = sqlite3_column_int(stmt, 0);
+            strncpy(e->name, (const char *)sqlite3_column_text(stmt, 1), sizeof(e->name) - 1);
+            strncpy(e->description, (const char *)sqlite3_column_text(stmt, 2), sizeof(e->description) - 1);
+        }
+        sqlite3_finalize(stmt);
+    }
+
+    ESP_LOGI(TAG, "Initialisation des elevages");
+}
+
+static int find_index(int id)
+{
+    for (int i = 0; i < elevage_count; ++i) {
+        if (elevages[i].id == id)
+            return i;
+    }
+    return -1;
+}
+
+bool elevages_add(const Elevage *e)
+{
+    if (elevage_count >= ELEVAGES_MAX || !e)
+        return false;
+    if (!db_exec("INSERT INTO elevages(id,name,description) VALUES(%d,'%s','%s');",
+                 e->id, e->name, e->description))
+        return false;
+    elevages[elevage_count] = *e;
+    elevage_count++;
+    ESP_LOGI(TAG, "Ajout de l'elevage %d", e->id);
+    return true;
+}
+
+const Elevage *elevages_get(int id)
+{
+    int idx = find_index(id);
+    if (idx >= 0)
+        return &elevages[idx];
+    return NULL;
+}
+
+bool elevages_update(int id, const Elevage *e)
+{
+    int idx = find_index(id);
+    if (idx < 0 || !e)
+        return false;
+    if (!db_exec("UPDATE elevages SET name='%s',description='%s' WHERE id=%d;",
+                 e->name, e->description, id))
+        return false;
+    elevages[idx] = *e;
+    ESP_LOGI(TAG, "Mise a jour de l'elevage %d", id);
+    return true;
+}
+
+bool elevages_delete(int id)
+{
+    int idx = find_index(id);
+    if (idx < 0)
+        return false;
+    if (!db_exec("DELETE FROM elevages WHERE id=%d;", id))
+        return false;
+    for (int i = idx; i < elevage_count - 1; ++i) {
+        elevages[i] = elevages[i + 1];
+    }
+    elevage_count--;
+    ESP_LOGI(TAG, "Suppression de l'elevage %d", id);
+    return true;
+}
+
+int elevages_count(void)
+{
+    return elevage_count;
+}
+
+const Elevage *elevages_get_by_index(int index)
+{
+    if (index < 0 || index >= elevage_count)
+        return NULL;
+    return &elevages[index];
+}

--- a/components/elevages/elevages.h
+++ b/components/elevages/elevages.h
@@ -1,0 +1,22 @@
+#ifndef ELEVAGES_H
+#define ELEVAGES_H
+
+#include <stdbool.h>
+
+#define ELEVAGES_MAX 10
+
+typedef struct {
+    int id;
+    char name[32];
+    char description[64];
+} Elevage;
+
+void elevages_init(void);
+bool elevages_add(const Elevage *e);
+const Elevage *elevages_get(int id);
+bool elevages_update(int id, const Elevage *e);
+bool elevages_delete(int id);
+int elevages_count(void);
+const Elevage *elevages_get_by_index(int index);
+
+#endif // ELEVAGES_H

--- a/components/ui/ui.c
+++ b/components/ui/ui.c
@@ -11,6 +11,7 @@ static const char *TAG = "ui";
 
 static ui_language_t current_lang = UI_LANG_EN;
 static ui_theme_t current_theme = UI_THEME_LIGHT;
+static int current_elevage_id = 0;
 
 static const char *translations[UI_LANG_COUNT][TXT_COUNT] = {
     [UI_LANG_EN] = {
@@ -43,13 +44,15 @@ static const char *translations[UI_LANG_COUNT][TXT_COUNT] = {
 
 static lv_obj_t *tabview;
 static lv_obj_t *notif_label;
+static lv_obj_t *tab_animals;
+static lv_obj_t *tab_terrariums;
 
 static void animals_tab_create(lv_obj_t *tab)
 {
     lv_obj_t *list = lv_list_create(tab);
     lv_obj_set_size(list, 380, 420);
-    for (int i = 0; i < animals_count(); ++i) {
-        const Reptile *r = animals_get_by_index(i);
+    for (int i = 0; i < animals_count_for_elevage(current_elevage_id); ++i) {
+        const Reptile *r = animals_get_by_index_for_elevage(i, current_elevage_id);
         if (!r) continue;
         const char *status = (legal_is_cerfa_valid(r) && legal_is_cites_valid(r)) ?
                                 ui_get_text(TXT_LEGAL_OK) : ui_get_text(TXT_LEGAL_EXPIRED);
@@ -64,8 +67,8 @@ static void terrariums_tab_create(lv_obj_t *tab)
 {
     lv_obj_t *list = lv_list_create(tab);
     lv_obj_set_size(list, 380, 420);
-    for (int i = 0; i < terrariums_count_for_elevage(0); ++i) {
-        const Terrarium *t = terrariums_get_by_index_for_elevage(i, 0);
+    for (int i = 0; i < terrariums_count_for_elevage(current_elevage_id); ++i) {
+        const Terrarium *t = terrariums_get_by_index_for_elevage(i, current_elevage_id);
         if (!t) continue;
         char buf[64];
         snprintf(buf, sizeof(buf), "%s (%d)", t->name, t->capacity);
@@ -99,6 +102,22 @@ static void transactions_tab_create(lv_obj_t *tab)
                  tr->quantity);
         lv_list_add_btn(list, NULL, buf);
     }
+}
+
+void ui_set_elevage(int elevage_id)
+{
+    current_elevage_id = elevage_id;
+    if (tab_animals && tab_terrariums) {
+        lv_obj_clean(tab_animals);
+        lv_obj_clean(tab_terrariums);
+        animals_tab_create(tab_animals);
+        terrariums_tab_create(tab_terrariums);
+    }
+}
+
+int ui_get_elevage(void)
+{
+    return current_elevage_id;
 }
 
 static void export_event(lv_event_t *e)
@@ -200,14 +219,14 @@ void ui_init(ui_language_t lang, ui_theme_t theme)
     tabview = lv_tabview_create(lv_scr_act(), LV_DIR_TOP, 40);
     lv_obj_set_size(tabview, 800, 480);
 
-    lv_obj_t *tab1 = lv_tabview_add_tab(tabview, ui_get_text(TXT_ANIMALS));
-    lv_obj_t *tab2 = lv_tabview_add_tab(tabview, ui_get_text(TXT_TERRARIUMS));
+    tab_animals = lv_tabview_add_tab(tabview, ui_get_text(TXT_ANIMALS));
+    tab_terrariums = lv_tabview_add_tab(tabview, ui_get_text(TXT_TERRARIUMS));
     lv_obj_t *tab3 = lv_tabview_add_tab(tabview, ui_get_text(TXT_STOCKS));
     lv_obj_t *tab4 = lv_tabview_add_tab(tabview, ui_get_text(TXT_TRANSACTIONS));
     lv_obj_t *tab5 = lv_tabview_add_tab(tabview, ui_get_text(TXT_SETTINGS));
 
-    animals_tab_create(tab1);
-    terrariums_tab_create(tab2);
+    animals_tab_create(tab_animals);
+    terrariums_tab_create(tab_terrariums);
     stocks_tab_create(tab3);
     transactions_tab_create(tab4);
     settings_tab_create(tab5);

--- a/components/ui/ui.h
+++ b/components/ui/ui.h
@@ -64,4 +64,7 @@ const char *ui_get_text(ui_text_id_t id);
  */
 void ui_notify(const char *msg);
 
+void ui_set_elevage(int elevage_id);
+int ui_get_elevage(void);
+
 #endif // UI_H

--- a/main/main.c
+++ b/main/main.c
@@ -8,6 +8,7 @@
 #include "auth.h"
 #include "legal.h"
 #include "storage.h"
+#include "elevages.h"
 #include "animals.h"
 #include "terrariums.h"
 #include "stocks.h"
@@ -25,6 +26,7 @@ void app_main(void)
     // Initialisation de LVGL et de l'interface
     lv_init();
     ui_init(UI_LANG_EN, UI_THEME_LIGHT);
+    ui_set_elevage(0);
 
     // Initialisation de la base de données
     db_init();
@@ -33,6 +35,7 @@ void app_main(void)
     auth_init();
 
     // Initialisation des modules metier
+    elevages_init();
     animals_init();
     terrariums_init();
     stocks_init();


### PR DESCRIPTION
## Summary
- create new `elevages` component
- link authentication users to elevage ids
- filter UI lists by current elevage
- add elevages table and export support in DB
- initialize elevages in main

## Testing
- `make --version`
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe9a401948323ba6d55470dc45b88