### PR TITLE
Add unit tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: espressif/github-actions/setup-esp-idf@v1
+        with:
+          version: latest
+      - name: Build
+        run: idf.py build
+      - name: Run unit tests
+        run: idf.py build && idf.py unity_test

--- a/components/db/db.c
+++ b/components/db/db.c
@@ -13,6 +13,65 @@ static const char *TAG = "db";
 static sqlite3 *db_handle = NULL;
 static char db_key[64];
 
+static bool open_db(const char *path)
+{
+    if (sqlite3_open(path, &db_handle) != SQLITE_OK) {
+        ESP_LOGE(TAG, "Impossible d'ouvrir la base de données: %s", sqlite3_errmsg(db_handle));
+        return false;
+    }
+#ifdef SQLITE_HAS_CODEC
+    if (db_key[0] != '\0') {
+        sqlite3_key(db_handle, db_key, strlen(db_key));
+    }
+#endif
+    return true;
+}
+
+static void create_tables(void)
+{
+    exec_simple("CREATE TABLE IF NOT EXISTS elevages(""
+                "id INTEGER PRIMARY KEY,""
+                "name TEXT,""
+                "description TEXT);");
+
+    exec_simple("CREATE TABLE IF NOT EXISTS animals(""
+                "id INTEGER PRIMARY KEY,""
+                "elevage_id INTEGER,""
+                "name TEXT,""
+                "species TEXT,""
+                "sex TEXT,""
+                "birth_date TEXT,""
+                "health TEXT,""
+                "breeding_cycle TEXT);");
+
+    exec_simple("CREATE TABLE IF NOT EXISTS terrariums(""
+                "id INTEGER PRIMARY KEY,""
+                "elevage_id INTEGER,""
+                "name TEXT,""
+                "capacity INTEGER,""
+                "inventory TEXT,""
+                "notes TEXT);");
+
+    exec_simple("CREATE TABLE IF NOT EXISTS terrarium_logs(""
+                "id INTEGER PRIMARY KEY AUTOINCREMENT,""
+                "terrarium_id INTEGER,""
+                "message TEXT,""
+                "timestamp INTEGER DEFAULT (strftime('%s','now')));");
+
+    exec_simple("CREATE TABLE IF NOT EXISTS stocks(""
+                "id INTEGER PRIMARY KEY,""
+                "name TEXT,""
+                "quantity INTEGER,""
+                "min_quantity INTEGER);");
+
+    exec_simple("CREATE TABLE IF NOT EXISTS transactions(""
+                "id INTEGER PRIMARY KEY AUTOINCREMENT,""
+                "stock_id INTEGER,""
+                "quantity INTEGER,""
+                "type TEXT,""
+                "timestamp INTEGER DEFAULT (strftime('%s','now')));");
+}
+
 static void load_db_key(void)
 {
     nvs_handle_t h;
@@ -90,6 +149,22 @@ sqlite3_stmt *db_query(const char *format, ...)
         return NULL;
     }
     return stmt;
+}
+
+bool db_open_custom(const char *path)
+{
+    if (!open_db(path))
+        return false;
+    create_tables();
+    return true;
+}
+
+void db_close(void)
+{
+    if (db_handle) {
+        sqlite3_close(db_handle);
+        db_handle = NULL;
+    }
 }
 
 void db_init(void)

--- a/components/db/db.h
+++ b/components/db/db.h
@@ -45,4 +45,18 @@ sqlite3_stmt *db_query(const char *format, ...);
  */
 bool db_set_key(const char *key);
 
+/**
+ * \brief Ouvre la base de données à un chemin personnalisé.
+ *        Utilisé principalement pour les tests unitaires.
+ * \param path Chemin du fichier SQLite ou ":memory:".
+ * \return true si l'ouverture a réussi.
+ */
+bool db_open_custom(const char *path);
+
+/**
+ * \brief Ferme la base de données courante.
+ */
+void db_close(void);
+
+
 #endif // DB_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "test_auth.c" "test_db.c" "test_legal.c"
+                       INCLUDE_DIRS ".."
+                       REQUIRES db auth legal animals unity)

--- a/tests/test_auth.c
+++ b/tests/test_auth.c
@@ -1,0 +1,19 @@
+#include "unity.h"
+#include "auth.h"
+
+TEST_CASE("auth add and check","[auth]")
+{
+    auth_init();
+    TEST_ASSERT_TRUE(auth_add_user("user1","pass1", ROLE_PARTICULIER));
+    TEST_ASSERT_TRUE(auth_check("user1","pass1"));
+    TEST_ASSERT_FALSE(auth_check("user1","wrong"));
+}
+
+TEST_CASE("auth elevage link","[auth]")
+{
+    auth_init();
+    auth_add_user("user2","pass2", ROLE_PARTICULIER);
+    TEST_ASSERT_TRUE(auth_link_elevage("user2", 42));
+    TEST_ASSERT_EQUAL_INT(1, auth_get_elevage_count("user2"));
+    TEST_ASSERT_EQUAL_INT(42, auth_get_elevage_by_index("user2",0));
+}

--- a/tests/test_db.c
+++ b/tests/test_db.c
@@ -1,0 +1,17 @@
+#include "unity.h"
+#include "db.h"
+#include <sqlite3.h>
+
+TEST_CASE("db exec and query","[db]")
+{
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    TEST_ASSERT_TRUE(db_exec("CREATE TABLE test(id INTEGER PRIMARY KEY, name TEXT);"));
+    TEST_ASSERT_TRUE(db_exec("INSERT INTO test(id,name) VALUES(1,'foo');"));
+    sqlite3_stmt *stmt = db_query("SELECT name FROM test WHERE id=%d;",1);
+    TEST_ASSERT_NOT_NULL(stmt);
+    TEST_ASSERT_EQUAL_INT(SQLITE_ROW, sqlite3_step(stmt));
+    TEST_ASSERT_EQUAL_STRING("foo", (const char*)sqlite3_column_text(stmt,0));
+    sqlite3_finalize(stmt);
+    db_close();
+}

--- a/tests/test_legal.c
+++ b/tests/test_legal.c
@@ -1,0 +1,44 @@
+#include "unity.h"
+#include "legal.h"
+#include "animals.h"
+#include <sys/stat.h>
+#include <unistd.h>
+#include <time.h>
+
+TEST_CASE("legal document generation","[legal]")
+{
+    Reptile r = {
+        .name = "Test",
+        .species = "Lizard",
+        .sex = "M",
+        .birth_date = "2020-01-01",
+        .cdc_number = "CDC12345",
+        .aoe_number = "AOE12345",
+        .ifap_id = "ID1",
+        .quota_limit = 10,
+        .quota_used = 1,
+        .cerfa_valid_until = (int)time(NULL)+3600,
+        .cites_valid_until = (int)time(NULL)+3600
+    };
+    TEST_ASSERT_TRUE(legal_generate_cerfa("cerfa_test.pdf", &r));
+    struct stat st; 
+    TEST_ASSERT_EQUAL_INT(0, stat("cerfa_test.pdf", &st));
+    unlink("cerfa_test.pdf");
+}
+
+TEST_CASE("legal validation","[legal]")
+{
+    Reptile r = {
+        .cdc_number = "CDC12345",
+        .aoe_number = "AOE67890",
+        .cerfa_valid_until = (int)time(NULL)+3600,
+        .cites_valid_until = (int)time(NULL)+3600,
+        .quota_limit = 2,
+        .quota_used = 1
+    };
+    TEST_ASSERT_TRUE(legal_is_cdc_valid(&r));
+    TEST_ASSERT_TRUE(legal_is_aoe_valid(&r));
+    TEST_ASSERT_TRUE(legal_is_cerfa_valid(&r));
+    TEST_ASSERT_TRUE(legal_is_cites_valid(&r));
+    TEST_ASSERT_TRUE(legal_quota_remaining(&r));
+}


### PR DESCRIPTION
## Summary
- add custom DB open helpers for tests
- unit tests for database, authentication and legal modules
- enable CI workflow for build & tests

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685feb9adc488323b7656abe05105ce3