### PR TITLE
Add health/breeding record support

### DIFF
--- a/components/animals/CMakeLists.txt
+++ b/components/animals/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "animals.c"
+idf_component_register(SRCS "animals.c" "health.c" "breeding.c"
                        INCLUDE_DIRS ".")

--- a/components/animals/breeding.c
+++ b/components/animals/breeding.c
@@ -1,0 +1,122 @@
+#include "breeding.h"
+#include "esp_log.h"
+#include "db.h"
+#include <sqlite3.h>
+#include <string.h>
+
+static const char *TAG = "breeding";
+
+static BreedingEvent events[BREEDING_MAX];
+static int event_count = 0;
+
+static int find_index(int id)
+{
+    for (int i = 0; i < event_count; ++i) {
+        if (events[i].id == id)
+            return i;
+    }
+    return -1;
+}
+
+void breeding_init(void)
+{
+    event_count = 0;
+    memset(events, 0, sizeof(events));
+
+    sqlite3_stmt *stmt = db_query("SELECT id,animal_id,description,date FROM breeding_events;");
+    if (stmt) {
+        while (sqlite3_step(stmt) == SQLITE_ROW && event_count < BREEDING_MAX) {
+            BreedingEvent *e = &events[event_count++];
+            e->id = sqlite3_column_int(stmt, 0);
+            e->animal_id = sqlite3_column_int(stmt, 1);
+            strncpy(e->description, (const char *)sqlite3_column_text(stmt, 2), sizeof(e->description) - 1);
+            e->date = sqlite3_column_int(stmt, 3);
+        }
+        sqlite3_finalize(stmt);
+    }
+    ESP_LOGI(TAG, "Initialisation des evenements reproduction");
+}
+
+bool breeding_add(const BreedingEvent *ev)
+{
+    if (event_count >= BREEDING_MAX || !ev)
+        return false;
+    if (!db_exec("INSERT INTO breeding_events(id,animal_id,description,date) VALUES(%d,%d,'%s',%d);",
+                 ev->id, ev->animal_id, ev->description, ev->date))
+        return false;
+    events[event_count] = *ev;
+    event_count++;
+    ESP_LOGI(TAG, "Ajout evenement reproduction %d", ev->id);
+    return true;
+}
+
+const BreedingEvent *breeding_get(int id)
+{
+    int idx = find_index(id);
+    if (idx >= 0)
+        return &events[idx];
+    return NULL;
+}
+
+bool breeding_update(int id, const BreedingEvent *ev)
+{
+    int idx = find_index(id);
+    if (idx < 0 || !ev)
+        return false;
+    if (!db_exec("UPDATE breeding_events SET animal_id=%d,description='%s',date=%d WHERE id=%d;",
+                 ev->animal_id, ev->description, ev->date, id))
+        return false;
+    events[idx] = *ev;
+    events[idx].id = id;
+    ESP_LOGI(TAG, "Mise a jour evenement reproduction %d", id);
+    return true;
+}
+
+bool breeding_delete(int id)
+{
+    int idx = find_index(id);
+    if (idx < 0)
+        return false;
+    if (!db_exec("DELETE FROM breeding_events WHERE id=%d;", id))
+        return false;
+    for (int i = idx; i < event_count - 1; ++i)
+        events[i] = events[i + 1];
+    event_count--;
+    ESP_LOGI(TAG, "Suppression evenement reproduction %d", id);
+    return true;
+}
+
+int breeding_count(void)
+{
+    return event_count;
+}
+
+const BreedingEvent *breeding_get_by_index(int index)
+{
+    if (index < 0 || index >= event_count)
+        return NULL;
+    return &events[index];
+}
+
+int breeding_count_for_animal(int animal_id)
+{
+    int cnt = 0;
+    for (int i = 0; i < event_count; ++i)
+        if (events[i].animal_id == animal_id)
+            cnt++;
+    return cnt;
+}
+
+const BreedingEvent *breeding_get_by_index_for_animal(int index, int animal_id)
+{
+    int current = 0;
+    for (int i = 0; i < event_count; ++i) {
+        if (events[i].animal_id == animal_id) {
+            if (current == index)
+                return &events[i];
+            current++;
+        }
+    }
+    return NULL;
+}
+

--- a/components/animals/breeding.h
+++ b/components/animals/breeding.h
@@ -1,0 +1,25 @@
+#ifndef BREEDING_H
+#define BREEDING_H
+
+#include <stdbool.h>
+
+#define BREEDING_MAX 100
+
+typedef struct {
+    int id;
+    int animal_id;
+    char description[64];
+    int date; /* timestamp */
+} BreedingEvent;
+
+void breeding_init(void);
+bool breeding_add(const BreedingEvent *ev);
+const BreedingEvent *breeding_get(int id);
+bool breeding_update(int id, const BreedingEvent *ev);
+bool breeding_delete(int id);
+int breeding_count(void);
+const BreedingEvent *breeding_get_by_index(int index);
+int breeding_count_for_animal(int animal_id);
+const BreedingEvent *breeding_get_by_index_for_animal(int index, int animal_id);
+
+#endif // BREEDING_H

--- a/components/animals/health.c
+++ b/components/animals/health.c
@@ -1,0 +1,122 @@
+#include "health.h"
+#include "esp_log.h"
+#include "db.h"
+#include <sqlite3.h>
+#include <string.h>
+
+static const char *TAG = "health";
+
+static HealthRecord records[HEALTH_MAX];
+static int record_count = 0;
+
+static int find_index(int id)
+{
+    for (int i = 0; i < record_count; ++i) {
+        if (records[i].id == id)
+            return i;
+    }
+    return -1;
+}
+
+void health_init(void)
+{
+    record_count = 0;
+    memset(records, 0, sizeof(records));
+
+    sqlite3_stmt *stmt = db_query("SELECT id,animal_id,description,date FROM health_records;");
+    if (stmt) {
+        while (sqlite3_step(stmt) == SQLITE_ROW && record_count < HEALTH_MAX) {
+            HealthRecord *r = &records[record_count++];
+            r->id = sqlite3_column_int(stmt, 0);
+            r->animal_id = sqlite3_column_int(stmt, 1);
+            strncpy(r->description, (const char *)sqlite3_column_text(stmt, 2), sizeof(r->description) - 1);
+            r->date = sqlite3_column_int(stmt, 3);
+        }
+        sqlite3_finalize(stmt);
+    }
+    ESP_LOGI(TAG, "Initialisation des fiches sante");
+}
+
+bool health_add(const HealthRecord *rec)
+{
+    if (record_count >= HEALTH_MAX || !rec)
+        return false;
+    if (!db_exec("INSERT INTO health_records(id,animal_id,description,date) VALUES(%d,%d,'%s',%d);",
+                 rec->id, rec->animal_id, rec->description, rec->date))
+        return false;
+    records[record_count] = *rec;
+    record_count++;
+    ESP_LOGI(TAG, "Ajout fiche sante %d", rec->id);
+    return true;
+}
+
+const HealthRecord *health_get(int id)
+{
+    int idx = find_index(id);
+    if (idx >= 0)
+        return &records[idx];
+    return NULL;
+}
+
+bool health_update(int id, const HealthRecord *rec)
+{
+    int idx = find_index(id);
+    if (idx < 0 || !rec)
+        return false;
+    if (!db_exec("UPDATE health_records SET animal_id=%d,description='%s',date=%d WHERE id=%d;",
+                 rec->animal_id, rec->description, rec->date, id))
+        return false;
+    records[idx] = *rec;
+    records[idx].id = id;
+    ESP_LOGI(TAG, "Mise a jour fiche sante %d", id);
+    return true;
+}
+
+bool health_delete(int id)
+{
+    int idx = find_index(id);
+    if (idx < 0)
+        return false;
+    if (!db_exec("DELETE FROM health_records WHERE id=%d;", id))
+        return false;
+    for (int i = idx; i < record_count - 1; ++i)
+        records[i] = records[i + 1];
+    record_count--;
+    ESP_LOGI(TAG, "Suppression fiche sante %d", id);
+    return true;
+}
+
+int health_count(void)
+{
+    return record_count;
+}
+
+const HealthRecord *health_get_by_index(int index)
+{
+    if (index < 0 || index >= record_count)
+        return NULL;
+    return &records[index];
+}
+
+int health_count_for_animal(int animal_id)
+{
+    int cnt = 0;
+    for (int i = 0; i < record_count; ++i)
+        if (records[i].animal_id == animal_id)
+            cnt++;
+    return cnt;
+}
+
+const HealthRecord *health_get_by_index_for_animal(int index, int animal_id)
+{
+    int current = 0;
+    for (int i = 0; i < record_count; ++i) {
+        if (records[i].animal_id == animal_id) {
+            if (current == index)
+                return &records[i];
+            current++;
+        }
+    }
+    return NULL;
+}
+

--- a/components/animals/health.h
+++ b/components/animals/health.h
@@ -1,0 +1,25 @@
+#ifndef HEALTH_H
+#define HEALTH_H
+
+#include <stdbool.h>
+
+#define HEALTH_MAX 100
+
+typedef struct {
+    int id;
+    int animal_id;
+    char description[64];
+    int date; /* timestamp */
+} HealthRecord;
+
+void health_init(void);
+bool health_add(const HealthRecord *rec);
+const HealthRecord *health_get(int id);
+bool health_update(int id, const HealthRecord *rec);
+bool health_delete(int id);
+int health_count(void);
+const HealthRecord *health_get_by_index(int index);
+int health_count_for_animal(int animal_id);
+const HealthRecord *health_get_by_index_for_animal(int index, int animal_id);
+
+#endif // HEALTH_H

--- a/components/db/db.c
+++ b/components/db/db.c
@@ -70,6 +70,17 @@ static void create_tables(void)
                 "quantity INTEGER,""
                 "type TEXT,""
                 "timestamp INTEGER DEFAULT (strftime('%s','now')));");
+    exec_simple("CREATE TABLE IF NOT EXISTS health_records("""
+                "id INTEGER PRIMARY KEY,"""
+                "animal_id INTEGER,"""
+                "description TEXT,"""
+                "date INTEGER);");
+
+    exec_simple("CREATE TABLE IF NOT EXISTS breeding_events("""
+                "id INTEGER PRIMARY KEY,"""
+                "animal_id INTEGER,"""
+                "description TEXT,"""
+                "date INTEGER);");
 }
 
 static void load_db_key(void)
@@ -233,6 +244,17 @@ void db_init(void)
                 "quantity INTEGER,""
                 "type TEXT,""
                 "timestamp INTEGER DEFAULT (strftime('%s','now')));");
+    exec_simple("CREATE TABLE IF NOT EXISTS health_records("""
+                "id INTEGER PRIMARY KEY,"""
+                "animal_id INTEGER,"""
+                "description TEXT,"""
+                "date INTEGER);");
+
+    exec_simple("CREATE TABLE IF NOT EXISTS breeding_events("""
+                "id INTEGER PRIMARY KEY,"""
+                "animal_id INTEGER,"""
+                "description TEXT,"""
+                "date INTEGER);");
 }
 
 void db_backup(void)

--- a/components/scheduler/scheduler.c
+++ b/components/scheduler/scheduler.c
@@ -5,6 +5,9 @@
 #include "ui.h"
 #include "stocks.h"
 #include "legal.h"
+#include "health.h"
+#include "breeding.h"
+#include <time.h>
 
 #define SCHEDULER_INTERVAL_MS 60000
 
@@ -39,6 +42,32 @@ static void check_compliance(void)
     notify("Verification de la conformite");
 }
 
+static void check_health_alerts(void)
+{
+    time_t now = time(NULL);
+    for (int i = 0; i < health_count(); ++i) {
+        const HealthRecord *r = health_get_by_index(i);
+        if (r && r->date <= now + 86400 && r->date >= now) {
+            char msg[64];
+            snprintf(msg, sizeof(msg), "Controle sante animal %d", r->animal_id);
+            notify(msg);
+        }
+    }
+}
+
+static void check_breeding_alerts(void)
+{
+    time_t now = time(NULL);
+    for (int i = 0; i < breeding_count(); ++i) {
+        const BreedingEvent *e = breeding_get_by_index(i);
+        if (e && e->date <= now + 86400 && e->date >= now) {
+            char msg[64];
+            snprintf(msg, sizeof(msg), "Evenement reproduction animal %d", e->animal_id);
+            notify(msg);
+        }
+    }
+}
+
 static void scheduler_task(void *arg)
 {
     (void)arg;
@@ -46,6 +75,8 @@ static void scheduler_task(void *arg)
         check_regulatory_deadlines();
         check_stock_levels();
         check_compliance();
+        check_health_alerts();
+        check_breeding_alerts();
         vTaskDelay(pdMS_TO_TICKS(SCHEDULER_INTERVAL_MS));
     }
 }

--- a/components/ui/ui.c
+++ b/components/ui/ui.c
@@ -5,6 +5,8 @@
 #include "stocks.h"
 #include "transactions.h"
 #include "legal.h"
+#include "health.h"
+#include "breeding.h"
 #include "storage.h"
 #include "auth.h"
 #include <stdlib.h>
@@ -73,6 +75,55 @@ typedef struct {
 } AnimalFormCtx;
 
 static AnimalFormCtx animal_form;
+
+static void close_win_event(lv_event_t *e)
+{
+    lv_obj_del(lv_obj_get_parent(lv_event_get_current_target(e)));
+}
+
+static void open_health_list(int animal_id)
+{
+    lv_obj_t *win = lv_obj_create(lv_scr_act());
+    lv_obj_set_size(win, 300, 200);
+    lv_obj_center(win);
+
+    lv_obj_t *list = lv_list_create(win);
+    lv_obj_set_size(list, 280, 160);
+    for (int i = 0; i < health_count_for_animal(animal_id); ++i) {
+        const HealthRecord *r = health_get_by_index_for_animal(i, animal_id);
+        if (!r) continue;
+        char buf[64];
+        snprintf(buf, sizeof(buf), "%d %s", r->date, r->description);
+        lv_list_add_btn(list, NULL, buf);
+    }
+
+    lv_obj_t *btn = lv_btn_create(win);
+    lv_obj_align(btn, LV_ALIGN_BOTTOM_RIGHT, -10, -10);
+    lv_obj_add_event_cb(btn, close_win_event, LV_EVENT_CLICKED, NULL);
+    lv_label_set_text(lv_label_create(btn), "Close");
+}
+
+static void open_breeding_list(int animal_id)
+{
+    lv_obj_t *win = lv_obj_create(lv_scr_act());
+    lv_obj_set_size(win, 300, 200);
+    lv_obj_center(win);
+
+    lv_obj_t *list = lv_list_create(win);
+    lv_obj_set_size(list, 280, 160);
+    for (int i = 0; i < breeding_count_for_animal(animal_id); ++i) {
+        const BreedingEvent *ev = breeding_get_by_index_for_animal(i, animal_id);
+        if (!ev) continue;
+        char buf[64];
+        snprintf(buf, sizeof(buf), "%d %s", ev->date, ev->description);
+        lv_list_add_btn(list, NULL, buf);
+    }
+
+    lv_obj_t *btn = lv_btn_create(win);
+    lv_obj_align(btn, LV_ALIGN_BOTTOM_RIGHT, -10, -10);
+    lv_obj_add_event_cb(btn, close_win_event, LV_EVENT_CLICKED, NULL);
+    lv_label_set_text(lv_label_create(btn), "Close");
+}
 
 typedef struct {
     lv_obj_t *win;
@@ -341,6 +392,18 @@ static void animal_delete_event(lv_event_t *e)
     refresh_animals();
 }
 
+static void health_list_event(lv_event_t *e)
+{
+    int id = (int)(intptr_t)lv_event_get_user_data(e);
+    open_health_list(id);
+}
+
+static void breeding_list_event(lv_event_t *e)
+{
+    int id = (int)(intptr_t)lv_event_get_user_data(e);
+    open_breeding_list(id);
+}
+
 static void open_animal_form(const Reptile *r)
 {
     animal_form.is_new = (r == NULL);
@@ -392,6 +455,16 @@ static void open_animal_form(const Reptile *r)
         lv_obj_align(btn_del, LV_ALIGN_BOTTOM_RIGHT, -10, -10);
         lv_obj_add_event_cb(btn_del, animal_delete_event, LV_EVENT_CLICKED, &animal_form);
         lv_label_set_text(lv_label_create(btn_del), "Delete");
+
+        lv_obj_t *btn_health = lv_btn_create(animal_form.win);
+        lv_obj_align(btn_health, LV_ALIGN_BOTTOM_MID, 0, -10);
+        lv_obj_add_event_cb(btn_health, health_list_event, LV_EVENT_CLICKED, (void *)(intptr_t)animal_form.orig_id);
+        lv_label_set_text(lv_label_create(btn_health), "Health");
+
+        lv_obj_t *btn_breed = lv_btn_create(animal_form.win);
+        lv_obj_align(btn_breed, LV_ALIGN_BOTTOM_MID, 0, -50);
+        lv_obj_add_event_cb(btn_breed, breeding_list_event, LV_EVENT_CLICKED, (void *)(intptr_t)animal_form.orig_id);
+        lv_label_set_text(lv_label_create(btn_breed), "Breeding");
     }
 }
 

--- a/tests/test_crud.c
+++ b/tests/test_crud.c
@@ -4,6 +4,8 @@
 #include "terrariums.h"
 #include "stocks.h"
 #include "transactions.h"
+#include "health.h"
+#include "breeding.h"
 
 TEST_CASE("animals crud","[animals]")
 {
@@ -75,5 +77,41 @@ TEST_CASE("transactions crud","[transactions]")
     TEST_ASSERT_EQUAL_INT(3, gt->quantity);
     TEST_ASSERT_TRUE(transactions_delete(1));
     TEST_ASSERT_NULL(transactions_get(1));
+    db_close();
+}
+
+TEST_CASE("health records crud","[health]")
+{
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    health_init();
+    HealthRecord hr = { .id=1, .animal_id=1, .description="check", .date=0 };
+    TEST_ASSERT_TRUE(health_add(&hr));
+    const HealthRecord *gr = health_get(1);
+    TEST_ASSERT_NOT_NULL(gr);
+    strcpy(hr.description, "done");
+    TEST_ASSERT_TRUE(health_update(1, &hr));
+    gr = health_get(1);
+    TEST_ASSERT_EQUAL_STRING("done", gr->description);
+    TEST_ASSERT_TRUE(health_delete(1));
+    TEST_ASSERT_NULL(health_get(1));
+    db_close();
+}
+
+TEST_CASE("breeding events crud","[breeding]")
+{
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    breeding_init();
+    BreedingEvent ev = { .id=1, .animal_id=1, .description="pair", .date=0 };
+    TEST_ASSERT_TRUE(breeding_add(&ev));
+    const BreedingEvent *ge = breeding_get(1);
+    TEST_ASSERT_NOT_NULL(ge);
+    strcpy(ev.description, "laid");
+    TEST_ASSERT_TRUE(breeding_update(1, &ev));
+    ge = breeding_get(1);
+    TEST_ASSERT_EQUAL_STRING("laid", ge->description);
+    TEST_ASSERT_TRUE(breeding_delete(1));
+    TEST_ASSERT_NULL(breeding_get(1));
     db_close();
 }


### PR DESCRIPTION
## Summary
- create helper modules `health` and `breeding`
- setup database tables for health records and breeding events
- expose alerts for upcoming events through scheduler
- display animal health and breeding logs via UI
- test CRUD helpers

## Testing
- `cmake -S . -B build` *(fails: Configuring incomplete, errors occurred)*

------
https://chatgpt.com/codex/tasks/task_e_685ff39916708323b23b4063a165daae