### PR TITLE
Add official PDF overlays and quota checks

### DIFF
--- a/components/legal/legal.c
+++ b/components/legal/legal.c
@@ -10,7 +10,11 @@
 static const char *TAG = "legal";
 
 static const char *cerfa_form_path = "forms/cerfa_base.pdf";
+static const char *cerfa_14367_form_path = "forms/cerfa_14367_base.pdf";
+static const char *cerfa_12447_form_path = "forms/cerfa_12447_base.pdf";
 static const char *cites_form_path = "forms/cites_base.pdf";
+static const char *cites_import_form_path = "forms/cites_import_base.pdf";
+static const char *cites_export_form_path = "forms/cites_export_base.pdf";
 
 static const char *valid_cdc_numbers[] = { "CDC12345", "CDC67890", NULL };
 static const char *valid_aoe_numbers[] = { "AOE12345", "AOE67890", NULL };
@@ -133,6 +137,48 @@ bool legal_generate_cites_official(const char *path, const Reptile *r)
     return write_overlay_pdf(cites_form_path, path, buffer);
 }
 
+bool legal_generate_cerfa_14367(const char *path, const Reptile *r)
+{
+    if (!r)
+        return false;
+    char buffer[512];
+    snprintf(buffer, sizeof(buffer), cerfa_14367_template,
+             r->name, r->species, r->sex, r->birth_date,
+             r->cdc_number, r->aoe_number, r->ifap_id);
+    return write_overlay_pdf(cerfa_14367_form_path, path, buffer);
+}
+
+bool legal_generate_cerfa_12447(const char *path, const Reptile *r)
+{
+    if (!r)
+        return false;
+    char buffer[256];
+    snprintf(buffer, sizeof(buffer), cerfa_12447_template,
+             r->name, r->species, r->sex, r->birth_date,
+             r->ifap_id);
+    return write_overlay_pdf(cerfa_12447_form_path, path, buffer);
+}
+
+bool legal_generate_cites_import(const char *path, const Reptile *r)
+{
+    if (!r)
+        return false;
+    char buffer[256];
+    snprintf(buffer, sizeof(buffer), cites_import_template,
+             r->name, r->species, r->ifap_id);
+    return write_overlay_pdf(cites_import_form_path, path, buffer);
+}
+
+bool legal_generate_cites_export(const char *path, const Reptile *r)
+{
+    if (!r)
+        return false;
+    char buffer[256];
+    snprintf(buffer, sizeof(buffer), cites_export_template,
+             r->name, r->species, r->ifap_id);
+    return write_overlay_pdf(cites_export_form_path, path, buffer);
+}
+
 bool legal_is_cerfa_valid(const Reptile *r)
 {
     if (!r)
@@ -171,6 +217,10 @@ bool legal_is_cites_valid(const Reptile *r)
 bool legal_quota_remaining(const Reptile *r)
 {
     if (!r)
+        return false;
+    if (r->quota_limit <= 0)
+        return true;
+    if (r->quota_used < 0)
         return false;
     return r->quota_used < r->quota_limit;
 }
@@ -229,6 +279,18 @@ void legal_generate_all(const char *dir, const Reptile *r)
 
     snprintf(path, sizeof(path), "%s/cites_officiel.pdf", dir);
     legal_generate_cites_official(path, r);
+
+    snprintf(path, sizeof(path), "%s/cerfa_14367.pdf", dir);
+    legal_generate_cerfa_14367(path, r);
+
+    snprintf(path, sizeof(path), "%s/cerfa_12447.pdf", dir);
+    legal_generate_cerfa_12447(path, r);
+
+    snprintf(path, sizeof(path), "%s/cites_import.pdf", dir);
+    legal_generate_cites_import(path, r);
+
+    snprintf(path, sizeof(path), "%s/cites_export.pdf", dir);
+    legal_generate_cites_export(path, r);
 
     snprintf(path, sizeof(path), "%s/invoice.pdf", dir);
     legal_generate_invoice(path, r);

--- a/components/legal/legal.h
+++ b/components/legal/legal.h
@@ -10,6 +10,10 @@ bool legal_generate_cites(const char *path, const Reptile *r);
 bool legal_generate_invoice(const char *path, const Reptile *r);
 bool legal_generate_cerfa_official(const char *path, const Reptile *r);
 bool legal_generate_cites_official(const char *path, const Reptile *r);
+bool legal_generate_cerfa_14367(const char *path, const Reptile *r);
+bool legal_generate_cerfa_12447(const char *path, const Reptile *r);
+bool legal_generate_cites_import(const char *path, const Reptile *r);
+bool legal_generate_cites_export(const char *path, const Reptile *r);
 
 bool legal_is_cerfa_valid(const Reptile *r);
 bool legal_is_cites_valid(const Reptile *r);

--- a/components/legal/legal_templates.c
+++ b/components/legal/legal_templates.c
@@ -39,3 +39,33 @@ const char cites_official_template[] =
     "Nom: %s\n"
     "Espece: %s\n"
     "I-FAP: %s\n";
+
+const char cerfa_14367_template[] =
+    "CERFA 14367\n"
+    "Nom: %s\n"
+    "Espece: %s\n"
+    "Sexe: %s\n"
+    "Date de naissance: %s\n"
+    "CDC: %s\n"
+    "AOE: %s\n"
+    "I-FAP: %s\n";
+
+const char cerfa_12447_template[] =
+    "CERFA 12447\n"
+    "Nom: %s\n"
+    "Espece: %s\n"
+    "Sexe: %s\n"
+    "Date de naissance: %s\n"
+    "I-FAP: %s\n";
+
+const char cites_import_template[] =
+    "CITES Import\n"
+    "Nom: %s\n"
+    "Espece: %s\n"
+    "I-FAP: %s\n";
+
+const char cites_export_template[] =
+    "CITES Export\n"
+    "Nom: %s\n"
+    "Espece: %s\n"
+    "I-FAP: %s\n";

--- a/components/legal/legal_templates.h
+++ b/components/legal/legal_templates.h
@@ -7,5 +7,9 @@ extern const char cites_template[];
 extern const char invoice_template[];
 extern const char cerfa_official_template[];
 extern const char cites_official_template[];
+extern const char cerfa_14367_template[];
+extern const char cerfa_12447_template[];
+extern const char cites_import_template[];
+extern const char cites_export_template[];
 
 #endif // LEGAL_TEMPLATES_H

--- a/docs/LEGAL_TEMPLATES.md
+++ b/docs/LEGAL_TEMPLATES.md
@@ -1,0 +1,24 @@
+# Modèles officiels CERFA et CITES
+
+Ce projet utilise des gabarits PDF sur lesquels sont superposées les informations
+issues de la base de données. Les formulaires vierges ne sont pas fournis pour
+raison de droits d'auteur. Vous pouvez les télécharger gratuitement depuis les
+sites officiels suivants :
+
+- [service-public.fr](https://www.service-public.fr/) pour les différents CERFA
+  (ex. 14367 et 12447).
+- [cites.org](https://cites.org/) pour les certificats CITES d'import/export.
+
+Placez les PDFs originaux dans le répertoire `forms/` en conservant les noms
+suivants :
+
+- `cerfa_14367_base.pdf`
+- `cerfa_12447_base.pdf`
+- `cites_import_base.pdf`
+- `cites_export_base.pdf`
+
+Les exemples fournis dans ce dépôt sont de simples fichiers factices permettant
+uniquement de tester la génération de documents. Pour adapter les superpositions
+à votre version des formulaires, modifiez les chaînes définies dans
+`components/legal/legal_templates.c` en ajustant le texte et les positions
+si nécessaire.

--- a/forms/cerfa_12447_base.pdf
+++ b/forms/cerfa_12447_base.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] >>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000010 00000 n 
+0000000063 00000 n 
+0000000115 00000 n 
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+159
+%%EOF

--- a/forms/cerfa_14367_base.pdf
+++ b/forms/cerfa_14367_base.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] >>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000010 00000 n 
+0000000063 00000 n 
+0000000115 00000 n 
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+159
+%%EOF

--- a/forms/cites_export_base.pdf
+++ b/forms/cites_export_base.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] >>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000010 00000 n 
+0000000063 00000 n 
+0000000115 00000 n 
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+159
+%%EOF

--- a/forms/cites_import_base.pdf
+++ b/forms/cites_import_base.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] >>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000010 00000 n 
+0000000063 00000 n 
+0000000115 00000 n 
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+159
+%%EOF

--- a/tests/test_legal.c
+++ b/tests/test_legal.c
@@ -21,9 +21,12 @@ TEST_CASE("legal document generation","[legal]")
         .cites_valid_until = (int)time(NULL)+3600
     };
     TEST_ASSERT_TRUE(legal_generate_cerfa("cerfa_test.pdf", &r));
-    struct stat st; 
+    TEST_ASSERT_TRUE(legal_generate_cerfa_14367("cerfa_14367_test.pdf", &r));
+    struct stat st;
     TEST_ASSERT_EQUAL_INT(0, stat("cerfa_test.pdf", &st));
+    TEST_ASSERT_EQUAL_INT(0, stat("cerfa_14367_test.pdf", &st));
     unlink("cerfa_test.pdf");
+    unlink("cerfa_14367_test.pdf");
 }
 
 TEST_CASE("legal validation","[legal]")
@@ -41,4 +44,15 @@ TEST_CASE("legal validation","[legal]")
     TEST_ASSERT_TRUE(legal_is_cerfa_valid(&r));
     TEST_ASSERT_TRUE(legal_is_cites_valid(&r));
     TEST_ASSERT_TRUE(legal_quota_remaining(&r));
+}
+
+TEST_CASE("quota edge cases","[legal]")
+{
+    Reptile r = { .quota_limit = 0, .quota_used = 5 };
+    TEST_ASSERT_TRUE(legal_quota_remaining(&r));
+    r.quota_limit = 5;
+    r.quota_used = 5;
+    TEST_ASSERT_FALSE(legal_quota_remaining(&r));
+    r.quota_used = -1;
+    TEST_ASSERT_FALSE(legal_quota_remaining(&r));
 }


### PR DESCRIPTION
## Summary
- expand legal component with detailed PDF overlays
- add more robust quota validation
- generate additional CERFA and CITES forms
- document where to get official templates and how to customize them
- cover new cases with unit tests

## Testing
- `idf.py build` *(fails: command not found)*
- `idf.py unity_test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff7c6d8108323b7e67148e0a140cf