### PR TITLE
Add log loading to terrarium init

### DIFF
--- a/components/terrariums/terrariums.c
+++ b/components/terrariums/terrariums.c
@@ -11,7 +11,7 @@ static int terrarium_count = 0;
 static char logs[LOGS_MAX][64];
 static int log_count = 0;
 
-void terrariums_init(void)
+void terrariums_init(int log_offset)
 {
     terrarium_count = 0;
     log_count = 0;
@@ -29,6 +29,22 @@ void terrariums_init(void)
             strncpy(t->notes, (const char *)sqlite3_column_text(stmt, 5), sizeof(t->notes) - 1);
         }
         sqlite3_finalize(stmt);
+    }
+
+    // Chargement des logs existants avec pagination
+    sqlite3_stmt *log_stmt = db_query(
+        "SELECT message FROM terrarium_logs ORDER BY id DESC LIMIT %d OFFSET %d;",
+        LOGS_MAX, log_offset);
+    if (log_stmt) {
+        while (sqlite3_step(log_stmt) == SQLITE_ROW && log_count < LOGS_MAX) {
+            const unsigned char *msg = sqlite3_column_text(log_stmt, 0);
+            if (msg) {
+                strncpy(logs[log_count], (const char *)msg, sizeof(logs[0]) - 1);
+                logs[log_count][sizeof(logs[0]) - 1] = '\0';
+                log_count++;
+            }
+        }
+        sqlite3_finalize(log_stmt);
     }
 
     ESP_LOGI(TAG, "Initialisation des terrariums");

--- a/components/terrariums/terrariums.h
+++ b/components/terrariums/terrariums.h
@@ -19,9 +19,12 @@ typedef struct {
 } Terrarium;
 
 /**
- * \brief Initialise la liste des terrariums.
+ * \brief Initialise la liste des terrariums et charge les logs.
+ *
+ * \param log_offset Decalage dans l'historique des logs pour la pagination.
+ *                   Utiliser 0 pour recuperer les dernieres entrees.
  */
-void terrariums_init(void);
+void terrariums_init(int log_offset);
 
 /**
  * \brief Ajoute un terrarium.

--- a/main/main.c
+++ b/main/main.c
@@ -37,7 +37,7 @@ void app_main(void)
     // Initialisation des modules metier
     elevages_init();
     animals_init();
-    terrariums_init();
+    terrariums_init(0);
     stocks_init();
     transactions_init();
     scheduler_init();

--- a/tests/test_crud.c
+++ b/tests/test_crud.c
@@ -30,7 +30,7 @@ TEST_CASE("terrariums crud","[terrariums]")
 {
     db_set_key("");
     TEST_ASSERT_TRUE(db_open_custom(":memory:"));
-    terrariums_init();
+    terrariums_init(0);
     Terrarium t = { .id=1, .elevage_id=1, .name="T1", .capacity=2 };
     TEST_ASSERT_TRUE(terrariums_add(&t));
     const Terrarium *gt = terrariums_get(1);


### PR DESCRIPTION
## Summary
- load terrarium logs from database on init
- allow pagination of logs via offset parameter
- update main and tests to use new terrariums_init signature

## Testing
- `idf.py build` *(fails: command not found)*
- `idf.py unity_test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fff1721048323a0f8a7f3591683bd