### PR TITLE
Add scheduler and UI tests

### DIFF
--- a/components/scheduler/scheduler.c
+++ b/components/scheduler/scheduler.c
@@ -86,3 +86,13 @@ void scheduler_init(void)
     ESP_LOGI(TAG, "Initialisation du planificateur");
     xTaskCreate(scheduler_task, "scheduler", 4096, NULL, 5, NULL);
 }
+
+void scheduler_check_stock_levels(void)
+{
+    check_stock_levels();
+}
+
+void scheduler_check_regulatory_deadlines(void)
+{
+    check_regulatory_deadlines();
+}

--- a/components/scheduler/scheduler.h
+++ b/components/scheduler/scheduler.h
@@ -3,5 +3,7 @@
 
 /**\brief Initialise le planificateur de t\xC3\xA2ches. */
 void scheduler_init(void);
+void scheduler_check_stock_levels(void);
+void scheduler_check_regulatory_deadlines(void);
 
 #endif // SCHEDULER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
-idf_component_register(SRCS "test_auth.c" "test_db.c" "test_legal.c" "test_crud.c"
+idf_component_register(SRCS "test_auth.c" "test_db.c" "test_legal.c" "test_crud.c" \
+                       "test_scheduler.c" "test_ui.c"
                        INCLUDE_DIRS ".."
-                       REQUIRES db auth legal animals terrariums stocks transactions unity)
+                       REQUIRES db auth legal animals terrariums stocks transactions scheduler unity)

--- a/tests/test_scheduler.c
+++ b/tests/test_scheduler.c
@@ -1,0 +1,61 @@
+#include "unity.h"
+#include "db.h"
+#include "stocks.h"
+#include "animals.h"
+#include "legal.h"
+#include "scheduler.h"
+#include <string.h>
+#include <time.h>
+
+static char last_msg[64];
+
+void ui_notify(const char *msg)
+{
+    if (!msg) return;
+    strncpy(last_msg, msg, sizeof(last_msg) - 1);
+    last_msg[sizeof(last_msg) - 1] = '\0';
+}
+
+static void reset_msg(void)
+{
+    last_msg[0] = '\0';
+}
+
+TEST_CASE("scheduler low stock notification","[scheduler]")
+{
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    stocks_init();
+    StockItem s = { .id=1, .name="Crickets", .quantity=1, .min_quantity=2 };
+    TEST_ASSERT_TRUE(stocks_add(&s));
+    reset_msg();
+    scheduler_check_stock_levels();
+    TEST_ASSERT_EQUAL_STRING("Stock bas: Crickets", last_msg);
+    db_close();
+}
+
+TEST_CASE("scheduler document expiration warning","[scheduler]")
+{
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    animals_init();
+    time_t now = time(NULL);
+    Reptile r = {
+        .id = 1,
+        .elevage_id = 0,
+        .name = "Liz",
+        .species = "Lizard",
+        .cdc_number = "CDC12345",
+        .aoe_number = "AOE12345",
+        .ifap_id = "IFAP1",
+        .quota_limit = 10,
+        .quota_used = 0,
+        .cerfa_valid_until = now + 20 * 86400,
+        .cites_valid_until = now + 20 * 86400
+    };
+    TEST_ASSERT_TRUE(animals_add(&r));
+    reset_msg();
+    scheduler_check_regulatory_deadlines();
+    TEST_ASSERT_EQUAL_STRING("Documents bientot expir\xC3\xA9s", last_msg);
+    db_close();
+}

--- a/tests/test_ui.c
+++ b/tests/test_ui.c
@@ -1,0 +1,96 @@
+#include "unity.h"
+#include <string.h>
+
+typedef enum { UI_LANG_EN, UI_LANG_FR, UI_LANG_COUNT } ui_language_t;
+typedef enum { UI_THEME_LIGHT, UI_THEME_DARK, UI_THEME_COUNT } ui_theme_t;
+typedef enum {
+    TXT_ANIMALS,
+    TXT_TERRARIUMS,
+    TXT_STOCKS,
+    TXT_TRANSACTIONS,
+    TXT_SETTINGS,
+    TXT_EXPORT,
+    TXT_IMPORT,
+    TXT_LEGAL_OK,
+    TXT_LEGAL_EXPIRED,
+    TXT_LANGUAGE,
+    TXT_THEME,
+    TXT_LOGIN,
+    TXT_USERNAME,
+    TXT_PASSWORD,
+    TXT_COUNT
+} ui_text_id_t;
+
+static ui_language_t current_lang;
+static ui_theme_t current_theme;
+
+static const char *translations[UI_LANG_COUNT][TXT_COUNT] = {
+    [UI_LANG_EN] = {
+        [TXT_ANIMALS] = "Animals",
+        [TXT_TERRARIUMS] = "Terrariums",
+        [TXT_STOCKS] = "Stock",
+        [TXT_TRANSACTIONS] = "Transactions",
+        [TXT_SETTINGS] = "Settings",
+        [TXT_EXPORT] = "Export",
+        [TXT_IMPORT] = "Import",
+        [TXT_LEGAL_OK] = "OK",
+        [TXT_LEGAL_EXPIRED] = "Expired",
+        [TXT_LANGUAGE] = "Language",
+        [TXT_THEME] = "Theme",
+        [TXT_LOGIN] = "Login",
+        [TXT_USERNAME] = "Username",
+        [TXT_PASSWORD] = "Password",
+    },
+    [UI_LANG_FR] = {
+        [TXT_ANIMALS] = "Animaux",
+        [TXT_TERRARIUMS] = "Terrariums",
+        [TXT_STOCKS] = "Stocks",
+        [TXT_TRANSACTIONS] = "Transactions",
+        [TXT_SETTINGS] = "Param\xC3\xA8tres",
+        [TXT_EXPORT] = "Exporter",
+        [TXT_IMPORT] = "Importer",
+        [TXT_LEGAL_OK] = "OK",
+        [TXT_LEGAL_EXPIRED] = "Expire",
+        [TXT_LANGUAGE] = "Langue",
+        [TXT_THEME] = "Th\xC3\xA8me",
+        [TXT_LOGIN] = "Connexion",
+        [TXT_USERNAME] = "Utilisateur",
+        [TXT_PASSWORD] = "Mot de passe",
+    }
+};
+
+void ui_init(ui_language_t lang, ui_theme_t theme)
+{
+    current_lang = lang;
+    current_theme = theme;
+}
+
+void ui_set_language(ui_language_t lang)
+{
+    current_lang = lang;
+}
+
+void ui_set_theme(ui_theme_t theme)
+{
+    current_theme = theme;
+}
+
+const char *ui_get_text(ui_text_id_t id)
+{
+    return translations[current_lang][id];
+}
+
+TEST_CASE("ui language switching","[ui]")
+{
+    ui_init(UI_LANG_EN, UI_THEME_LIGHT);
+    TEST_ASSERT_EQUAL_STRING("Animals", ui_get_text(TXT_ANIMALS));
+    ui_set_language(UI_LANG_FR);
+    TEST_ASSERT_EQUAL_STRING("Animaux", ui_get_text(TXT_ANIMALS));
+}
+
+TEST_CASE("ui theme switching","[ui]")
+{
+    ui_init(UI_LANG_EN, UI_THEME_LIGHT);
+    ui_set_theme(UI_THEME_DARK);
+    TEST_ASSERT_EQUAL_INT(UI_THEME_DARK, current_theme);
+}


### PR DESCRIPTION
## Summary
- expose functions to trigger scheduler checks manually
- expand tests build list to include scheduler and UI tests
- test notifications for low stock and document expiry
- add stubbed LVGL/UI tests for language and theme switching

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686001ca93448323b85ed2ab2a8663ba