### PR TITLE
Add persistent user-elevage links

### DIFF
--- a/components/auth/auth.c
+++ b/components/auth/auth.c
@@ -74,6 +74,25 @@ void auth_init(void)
         sqlite3_finalize(stmt);
     }
 
+    stmt = db_query("SELECT username,elevage_id FROM user_elevages;");
+    if (stmt) {
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            const char *uname = (const char *)sqlite3_column_text(stmt, 0);
+            int elev_id = sqlite3_column_int(stmt, 1);
+            if (uname) {
+                for (int i = 0; i < user_count; ++i) {
+                    if (strcmp(users[i].username, uname) == 0) {
+                        if (users[i].elevage_count < AUTH_MAX_ELEVAGES_PER_USER) {
+                            users[i].elevages[users[i].elevage_count++] = elev_id;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        sqlite3_finalize(stmt);
+    }
+
     if (user_count == 0) {
         auth_add_user("admin", "changeme", ROLE_PARTICULIER);
         auth_link_elevage("admin", 0);
@@ -126,6 +145,9 @@ bool auth_link_elevage(const char *username, int elevage_id)
     for (int i = 0; i < user_count; ++i) {
         if (strcmp(users[i].username, username) == 0) {
             if (users[i].elevage_count >= AUTH_MAX_ELEVAGES_PER_USER)
+                return false;
+            if (!db_exec("INSERT INTO user_elevages(username,elevage_id) VALUES('%s',%d);",
+                         username, elevage_id))
                 return false;
             users[i].elevages[users[i].elevage_count++] = elevage_id;
             return true;

--- a/components/db/db.c
+++ b/components/db/db.c
@@ -74,6 +74,10 @@ static void create_tables(void)
                 "username TEXT PRIMARY KEY,""
                 "hash TEXT,""
                 "role INTEGER);");
+
+    exec_simple("CREATE TABLE IF NOT EXISTS user_elevages(""
+                "username TEXT,""
+                "elevage_id INTEGER);");
     exec_simple("CREATE TABLE IF NOT EXISTS health_records("""
                 "id INTEGER PRIMARY KEY,"""
                 "animal_id INTEGER,"""

--- a/tests/test_auth.c
+++ b/tests/test_auth.c
@@ -22,13 +22,19 @@ TEST_CASE("auth add and check","[auth]")
 TEST_CASE("auth elevage link","[auth]")
 {
     db_set_key("");
-    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    TEST_ASSERT_TRUE(db_open_custom("auth_elev.db"));
     auth_init();
     auth_add_user("user2","pass2", ROLE_PARTICULIER);
     TEST_ASSERT_TRUE(auth_link_elevage("user2", 42));
     TEST_ASSERT_EQUAL_INT(1, auth_get_elevage_count("user2"));
     TEST_ASSERT_EQUAL_INT(42, auth_get_elevage_by_index("user2",0));
     db_close();
+    TEST_ASSERT_TRUE(db_open_custom("auth_elev.db"));
+    auth_init();
+    TEST_ASSERT_EQUAL_INT(1, auth_get_elevage_count("user2"));
+    TEST_ASSERT_EQUAL_INT(42, auth_get_elevage_by_index("user2",0));
+    db_close();
+    unlink("auth_elev.db");
 }
 
 TEST_CASE("auth persistence","[auth]")


### PR DESCRIPTION
## Summary
- store user/elevage associations in new `user_elevages` table
- load this table when auth module initializes
- persist associations when linking elevages to users
- verify link persistence in `test_auth`

## Testing
- `idf.py build` *(fails: command not found)*
- `idf.py unity_test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686006dfeb6c83239e476577878a7722