### PR TITLE
Add scheduler compliance checks

### DIFF
--- a/components/scheduler/scheduler.c
+++ b/components/scheduler/scheduler.c
@@ -5,6 +5,7 @@
 #include "ui.h"
 #include "stocks.h"
 #include "legal.h"
+#include "animals.h"
 #include "health.h"
 #include "breeding.h"
 #include <time.h>
@@ -40,6 +41,17 @@ static void check_stock_levels(void)
 static void check_compliance(void)
 {
     notify("Verification de la conformite");
+    for (int i = 0; i < animals_count(); ++i) {
+        const Reptile *r = animals_get_by_index(i);
+        if (!r)
+            continue;
+        if (!legal_is_cdc_valid(r))
+            notify("CDC invalide");
+        if (!legal_is_aoe_valid(r))
+            notify("AOE invalide");
+        if (!legal_quota_remaining(r))
+            notify("Quota atteint");
+    }
 }
 
 static void check_health_alerts(void)
@@ -95,4 +107,9 @@ void scheduler_check_stock_levels(void)
 void scheduler_check_regulatory_deadlines(void)
 {
     check_regulatory_deadlines();
+}
+
+void scheduler_check_compliance(void)
+{
+    check_compliance();
 }

--- a/components/scheduler/scheduler.h
+++ b/components/scheduler/scheduler.h
@@ -5,5 +5,6 @@
 void scheduler_init(void);
 void scheduler_check_stock_levels(void);
 void scheduler_check_regulatory_deadlines(void);
+void scheduler_check_compliance(void);
 
 #endif // SCHEDULER_H

--- a/tests/test_scheduler.c
+++ b/tests/test_scheduler.c
@@ -59,3 +59,81 @@ TEST_CASE("scheduler document expiration warning","[scheduler]")
     TEST_ASSERT_EQUAL_STRING("Documents bientot expir\xC3\xA9s", last_msg);
     db_close();
 }
+
+TEST_CASE("scheduler compliance invalid cdc","[scheduler]")
+{
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    animals_init();
+    time_t now = time(NULL);
+    Reptile r = {
+        .id = 1,
+        .elevage_id = 0,
+        .name = "Liz",
+        .species = "Lizard",
+        .cdc_number = "BAD",
+        .aoe_number = "AOE12345",
+        .ifap_id = "IF1",
+        .quota_limit = 10,
+        .quota_used = 0,
+        .cerfa_valid_until = now + 86400,
+        .cites_valid_until = now + 86400
+    };
+    TEST_ASSERT_TRUE(animals_add(&r));
+    reset_msg();
+    scheduler_check_compliance();
+    TEST_ASSERT_EQUAL_STRING("CDC invalide", last_msg);
+    db_close();
+}
+
+TEST_CASE("scheduler compliance invalid aoe","[scheduler]")
+{
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    animals_init();
+    time_t now = time(NULL);
+    Reptile r = {
+        .id = 2,
+        .elevage_id = 0,
+        .name = "Liz2",
+        .species = "Lizard",
+        .cdc_number = "CDC12345",
+        .aoe_number = "BAD",
+        .ifap_id = "IF2",
+        .quota_limit = 10,
+        .quota_used = 0,
+        .cerfa_valid_until = now + 86400,
+        .cites_valid_until = now + 86400
+    };
+    TEST_ASSERT_TRUE(animals_add(&r));
+    reset_msg();
+    scheduler_check_compliance();
+    TEST_ASSERT_EQUAL_STRING("AOE invalide", last_msg);
+    db_close();
+}
+
+TEST_CASE("scheduler compliance quota reached","[scheduler]")
+{
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    animals_init();
+    time_t now = time(NULL);
+    Reptile r = {
+        .id = 3,
+        .elevage_id = 0,
+        .name = "Liz3",
+        .species = "Lizard",
+        .cdc_number = "CDC12345",
+        .aoe_number = "AOE12345",
+        .ifap_id = "IF3",
+        .quota_limit = 2,
+        .quota_used = 2,
+        .cerfa_valid_until = now + 86400,
+        .cites_valid_until = now + 86400
+    };
+    TEST_ASSERT_TRUE(animals_add(&r));
+    reset_msg();
+    scheduler_check_compliance();
+    TEST_ASSERT_EQUAL_STRING("Quota atteint", last_msg);
+    db_close();
+}


### PR DESCRIPTION
## Summary
- notify for CDC/AOE/quota compliance
- expose `scheduler_check_compliance()` API
- add unit tests for compliance notifications

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860078fac188323805a5e28afeb2434