### PR TITLE
Load CDC/AOE numbers from DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ idf.py build
 ## Utilisation
 Une fois flashé sur votre ESP32, le firmware démarre l'interface graphique en français ou en anglais selon la configuration. Les modules s'initialisent automatiquement puis le planificateur vérifie les tâches à venir. Consultez `docs/UI_USAGE.md` pour le détail des écrans et `docs/NOTICE.md` pour les avertissements légaux.
 
+## Gestion des numéros CDC/AOE
+Les numéros d'autorisation (CDC et AOE) ne sont plus codés en dur. Ils sont stockés dans la
+table `cdc_aoe_numbers`. Chaque entrée possède un `id`, éventuellement un `username`,
+un `elevage_id`, un `type` (`CDC` ou `AOE`) et le `number`. Utilisez les fonctions de
+`legal_numbers.h` pour manipuler ces listes et ajoutez vos valeurs pour que
+`legal_is_cdc_valid()` et `legal_is_aoe_valid()` fonctionnent correctement.
+
 ## Base de données chiffrée
 Si SQLCipher est disponible, la base `lizard.db` est chiffrée. Définissez
 `CONFIG_DB_DEFAULT_KEY` dans `sdkconfig` ou saisissez un mot de passe au

--- a/components/db/db.c
+++ b/components/db/db.c
@@ -89,6 +89,13 @@ static void create_tables(void)
                 "animal_id INTEGER,"""
                 "description TEXT,"""
                 "date INTEGER);");
+
+    exec_simple("CREATE TABLE IF NOT EXISTS cdc_aoe_numbers("""
+                "id INTEGER PRIMARY KEY,"""
+                "username TEXT,"""
+                "elevage_id INTEGER,"""
+                "type TEXT,"""
+                "number TEXT);");
 }
 
 static void load_db_key(void)

--- a/components/legal/legal.c
+++ b/components/legal/legal.c
@@ -1,5 +1,6 @@
 #include "legal.h"
 #include "legal_templates.h"
+#include "legal_numbers.h"
 #include "esp_log.h"
 #include "ui.h"
 #include <stdio.h>
@@ -16,8 +17,6 @@ static const char *cites_form_path = "forms/cites_base.pdf";
 static const char *cites_import_form_path = "forms/cites_import_base.pdf";
 static const char *cites_export_form_path = "forms/cites_export_base.pdf";
 
-static const char *valid_cdc_numbers[] = { "CDC12345", "CDC67890", NULL };
-static const char *valid_aoe_numbers[] = { "AOE12345", "AOE67890", NULL };
 
 static bool write_basic_pdf(const char *path, const char *content)
 {
@@ -186,25 +185,15 @@ bool legal_is_cerfa_valid(const Reptile *r)
     return r->cerfa_valid_until > (int)time(NULL);
 }
 
-static bool number_in_list(const char *num, const char *const list[])
-{
-    if (!num || !list)
-        return false;
-    for (int i = 0; list[i]; ++i) {
-        if (strcmp(num, list[i]) == 0)
-            return true;
-    }
-    return false;
-}
 
 bool legal_is_cdc_valid(const Reptile *r)
 {
-    return r && number_in_list(r->cdc_number, valid_cdc_numbers);
+    return r && legal_numbers_is_cdc_valid(r->cdc_number, NULL, r->elevage_id);
 }
 
 bool legal_is_aoe_valid(const Reptile *r)
 {
-    return r && number_in_list(r->aoe_number, valid_aoe_numbers);
+    return r && legal_numbers_is_aoe_valid(r->aoe_number, NULL, r->elevage_id);
 }
 
 bool legal_is_cites_valid(const Reptile *r)

--- a/components/legal_numbers/CMakeLists.txt
+++ b/components/legal_numbers/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "legal_numbers.c" \
+                       INCLUDE_DIRS ".")

--- a/components/legal_numbers/legal_numbers.c
+++ b/components/legal_numbers/legal_numbers.c
@@ -1,0 +1,141 @@
+#include "legal_numbers.h"
+#include "db.h"
+#include "esp_log.h"
+#include <sqlite3.h>
+#include <string.h>
+
+static const char *TAG = "legal_numbers";
+
+static LegalNumber numbers[LEGAL_NUMBERS_MAX];
+static int number_count = 0;
+
+static int find_index(int id)
+{
+    for (int i = 0; i < number_count; ++i) {
+        if (numbers[i].id == id)
+            return i;
+    }
+    return -1;
+}
+
+void legal_numbers_init(void)
+{
+    number_count = 0;
+    memset(numbers, 0, sizeof(numbers));
+
+    sqlite3_stmt *stmt = db_query("SELECT id,username,elevage_id,type,number FROM cdc_aoe_numbers;");
+    if (stmt) {
+        while (sqlite3_step(stmt) == SQLITE_ROW && number_count < LEGAL_NUMBERS_MAX) {
+            LegalNumber *n = &numbers[number_count++];
+            n->id = sqlite3_column_int(stmt, 0);
+            const unsigned char *u = sqlite3_column_text(stmt, 1);
+            if (u)
+                strncpy(n->username, (const char *)u, sizeof(n->username) - 1);
+            n->elevage_id = sqlite3_column_int(stmt, 2);
+            const unsigned char *t = sqlite3_column_text(stmt, 3);
+            if (t)
+                strncpy(n->type, (const char *)t, sizeof(n->type) - 1);
+            const unsigned char *num = sqlite3_column_text(stmt, 4);
+            if (num)
+                strncpy(n->number, (const char *)num, sizeof(n->number) - 1);
+        }
+        sqlite3_finalize(stmt);
+    }
+
+    ESP_LOGI(TAG, "Initialisation des numeros CDC/AOE");
+}
+
+bool legal_numbers_add(const LegalNumber *n)
+{
+    if (number_count >= LEGAL_NUMBERS_MAX || !n)
+        return false;
+    if (!db_exec("INSERT INTO cdc_aoe_numbers(id,username,elevage_id,type,number) VALUES(%d,'%s',%d,'%s','%s');",
+                 n->id, n->username, n->elevage_id, n->type, n->number))
+        return false;
+    numbers[number_count] = *n;
+    number_count++;
+    ESP_LOGI(TAG, "Ajout numero %d", n->id);
+    return true;
+}
+
+const LegalNumber *legal_numbers_get(int id)
+{
+    int idx = find_index(id);
+    if (idx >= 0)
+        return &numbers[idx];
+    return NULL;
+}
+
+bool legal_numbers_update(int id, const LegalNumber *n)
+{
+    int idx = find_index(id);
+    if (idx < 0 || !n)
+        return false;
+    if (!db_exec("UPDATE cdc_aoe_numbers SET username='%s',elevage_id=%d,type='%s',number='%s' WHERE id=%d;",
+                 n->username, n->elevage_id, n->type, n->number, id))
+        return false;
+    numbers[idx] = *n;
+    ESP_LOGI(TAG, "Mise a jour numero %d", id);
+    return true;
+}
+
+bool legal_numbers_delete(int id)
+{
+    int idx = find_index(id);
+    if (idx < 0)
+        return false;
+    if (!db_exec("DELETE FROM cdc_aoe_numbers WHERE id=%d;", id))
+        return false;
+    for (int i = idx; i < number_count - 1; ++i)
+        numbers[i] = numbers[i + 1];
+    number_count--;
+    ESP_LOGI(TAG, "Suppression numero %d", id);
+    return true;
+}
+
+int legal_numbers_count(void)
+{
+    return number_count;
+}
+
+const LegalNumber *legal_numbers_get_by_index(int index)
+{
+    if (index < 0 || index >= number_count)
+        return NULL;
+    return &numbers[index];
+}
+
+static bool number_matches(const LegalNumber *n, const char *number, const char *type, const char *username, int elevage_id)
+{
+    if (strcmp(n->type, type) != 0)
+        return false;
+    if (strcmp(n->number, number) != 0)
+        return false;
+    if (n->username[0] != '\0' && (!username || strcmp(n->username, username) != 0))
+        return false;
+    if (n->elevage_id != 0 && n->elevage_id != elevage_id)
+        return false;
+    return true;
+}
+
+static bool is_valid(const char *number, const char *type, const char *username, int elevage_id)
+{
+    if (!number)
+        return false;
+    for (int i = 0; i < number_count; ++i) {
+        if (number_matches(&numbers[i], number, type, username, elevage_id))
+            return true;
+    }
+    return false;
+}
+
+bool legal_numbers_is_cdc_valid(const char *number, const char *username, int elevage_id)
+{
+    return is_valid(number, "CDC", username, elevage_id);
+}
+
+bool legal_numbers_is_aoe_valid(const char *number, const char *username, int elevage_id)
+{
+    return is_valid(number, "AOE", username, elevage_id);
+}
+

--- a/components/legal_numbers/legal_numbers.h
+++ b/components/legal_numbers/legal_numbers.h
@@ -1,0 +1,26 @@
+#ifndef LEGAL_NUMBERS_H
+#define LEGAL_NUMBERS_H
+
+#include <stdbool.h>
+
+#define LEGAL_NUMBERS_MAX 100
+
+typedef struct {
+    int id;
+    char username[32];
+    int elevage_id; /* 0 for any */
+    char type[4];   /* "CDC" or "AOE" */
+    char number[32];
+} LegalNumber;
+
+void legal_numbers_init(void);
+bool legal_numbers_add(const LegalNumber *n);
+const LegalNumber *legal_numbers_get(int id);
+bool legal_numbers_update(int id, const LegalNumber *n);
+bool legal_numbers_delete(int id);
+int legal_numbers_count(void);
+const LegalNumber *legal_numbers_get_by_index(int index);
+bool legal_numbers_is_cdc_valid(const char *number, const char *username, int elevage_id);
+bool legal_numbers_is_aoe_valid(const char *number, const char *username, int elevage_id);
+
+#endif // LEGAL_NUMBERS_H

--- a/docs/LEGAL_NUMBERS.md
+++ b/docs/LEGAL_NUMBERS.md
@@ -1,0 +1,18 @@
+# Gestion des numéros CDC/AOE
+
+Les numéros utilisés pour vérifier la validité des documents sont stockés dans la table SQLite `cdc_aoe_numbers`.
+Chaque enregistrement contient :
+
+- `id` : identifiant unique
+- `username` : optionnel, pour restreindre un numéro à un utilisateur
+- `elevage_id` : optionnel (0 pour tous)
+- `type` : `CDC` ou `AOE`
+- `number` : le numéro à vérifier
+
+Utilisez les fonctions d'aide définies dans `legal_numbers.h` pour ajouter ou supprimer des numéros depuis votre application. Vous pouvez également insérer directement dans la base avec une requête SQL :
+
+```sql
+INSERT INTO cdc_aoe_numbers(id,username,elevage_id,type,number) VALUES(1,'admin',0,'CDC','CDC12345');
+```
+
+La liste est chargée à l'initialisation via `legal_numbers_init()`.

--- a/main/main.c
+++ b/main/main.c
@@ -7,6 +7,7 @@
 #include "db.h"
 #include "auth.h"
 #include "legal.h"
+#include "legal_numbers.h"
 #include "storage.h"
 #include "elevages.h"
 #include "animals.h"
@@ -35,6 +36,7 @@ void app_main(void)
     auth_init();
 
     // Initialisation des modules metier
+    legal_numbers_init();
     elevages_init();
     animals_init();
     terrariums_init(0);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "test_auth.c" "test_db.c" "test_legal.c" "test_crud.c" \
                        "test_scheduler.c" "test_ui.c"
                        INCLUDE_DIRS ".."
-                       REQUIRES db auth legal animals terrariums stocks transactions scheduler unity)
+                      REQUIRES db auth legal legal_numbers animals terrariums stocks transactions scheduler unity)

--- a/tests/test_crud.c
+++ b/tests/test_crud.c
@@ -6,6 +6,7 @@
 #include "transactions.h"
 #include "health.h"
 #include "breeding.h"
+#include "legal_numbers.h"
 
 TEST_CASE("animals crud","[animals]")
 {
@@ -113,5 +114,24 @@ TEST_CASE("breeding events crud","[breeding]")
     TEST_ASSERT_EQUAL_STRING("laid", ge->description);
     TEST_ASSERT_TRUE(breeding_delete(1));
     TEST_ASSERT_NULL(breeding_get(1));
+    db_close();
+}
+
+TEST_CASE("legal numbers crud","[legal_numbers]")
+{
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    legal_numbers_init();
+    LegalNumber n = { .id=1, .username="user", .elevage_id=0, .type="CDC", .number="CDC999" };
+    TEST_ASSERT_TRUE(legal_numbers_add(&n));
+    TEST_ASSERT_EQUAL_INT(1, legal_numbers_count());
+    const LegalNumber *gn = legal_numbers_get(1);
+    TEST_ASSERT_NOT_NULL(gn);
+    strcpy(n.number, "CDC888");
+    TEST_ASSERT_TRUE(legal_numbers_update(1,&n));
+    gn = legal_numbers_get(1);
+    TEST_ASSERT_EQUAL_STRING("CDC888", gn->number);
+    TEST_ASSERT_TRUE(legal_numbers_delete(1));
+    TEST_ASSERT_EQUAL_INT(0, legal_numbers_count());
     db_close();
 }

--- a/tests/test_legal.c
+++ b/tests/test_legal.c
@@ -1,5 +1,7 @@
 #include "unity.h"
 #include "legal.h"
+#include "legal_numbers.h"
+#include "db.h"
 #include "animals.h"
 #include <sys/stat.h>
 #include <unistd.h>
@@ -7,6 +9,14 @@
 
 TEST_CASE("legal document generation","[legal]")
 {
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    legal_numbers_init();
+    LegalNumber n1 = { .id=1, .username="", .elevage_id=0, .type="CDC", .number="CDC12345" };
+    LegalNumber n2 = { .id=2, .username="", .elevage_id=0, .type="AOE", .number="AOE12345" };
+    TEST_ASSERT_TRUE(legal_numbers_add(&n1));
+    TEST_ASSERT_TRUE(legal_numbers_add(&n2));
+
     Reptile r = {
         .name = "Test",
         .species = "Lizard",
@@ -27,10 +37,19 @@ TEST_CASE("legal document generation","[legal]")
     TEST_ASSERT_EQUAL_INT(0, stat("cerfa_14367_test.pdf", &st));
     unlink("cerfa_test.pdf");
     unlink("cerfa_14367_test.pdf");
+    db_close();
 }
 
 TEST_CASE("legal validation","[legal]")
 {
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    legal_numbers_init();
+    LegalNumber n1 = { .id=1, .username="", .elevage_id=0, .type="CDC", .number="CDC12345" };
+    LegalNumber n2 = { .id=2, .username="", .elevage_id=0, .type="AOE", .number="AOE67890" };
+    TEST_ASSERT_TRUE(legal_numbers_add(&n1));
+    TEST_ASSERT_TRUE(legal_numbers_add(&n2));
+
     Reptile r = {
         .cdc_number = "CDC12345",
         .aoe_number = "AOE67890",
@@ -44,6 +63,7 @@ TEST_CASE("legal validation","[legal]")
     TEST_ASSERT_TRUE(legal_is_cerfa_valid(&r));
     TEST_ASSERT_TRUE(legal_is_cites_valid(&r));
     TEST_ASSERT_TRUE(legal_quota_remaining(&r));
+    db_close();
 }
 
 TEST_CASE("quota edge cases","[legal]")

--- a/tests/test_scheduler.c
+++ b/tests/test_scheduler.c
@@ -3,6 +3,8 @@
 #include "stocks.h"
 #include "animals.h"
 #include "legal.h"
+#include "legal_numbers.h"
+#include "legal_numbers.h"
 #include "scheduler.h"
 #include <string.h>
 #include <time.h>
@@ -38,6 +40,11 @@ TEST_CASE("scheduler document expiration warning","[scheduler]")
 {
     db_set_key("");
     TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    legal_numbers_init();
+    LegalNumber n1={.id=1,.username="",.elevage_id=0,.type="CDC",.number="CDC12345"};
+    LegalNumber n2={.id=2,.username="",.elevage_id=0,.type="AOE",.number="AOE12345"};
+    TEST_ASSERT_TRUE(legal_numbers_add(&n1));
+    TEST_ASSERT_TRUE(legal_numbers_add(&n2));
     animals_init();
     time_t now = time(NULL);
     Reptile r = {
@@ -64,6 +71,11 @@ TEST_CASE("scheduler compliance invalid cdc","[scheduler]")
 {
     db_set_key("");
     TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    legal_numbers_init();
+    LegalNumber n1={.id=1,.username="",.elevage_id=0,.type="AOE",.number="AOE12345"};
+    TEST_ASSERT_TRUE(legal_numbers_add(&n1));
+    LegalNumber n2={.id=2,.username="",.elevage_id=0,.type="CDC",.number="CDC12345"};
+    TEST_ASSERT_TRUE(legal_numbers_add(&n2));
     animals_init();
     time_t now = time(NULL);
     Reptile r = {
@@ -90,6 +102,11 @@ TEST_CASE("scheduler compliance invalid aoe","[scheduler]")
 {
     db_set_key("");
     TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    legal_numbers_init();
+    LegalNumber n1={.id=1,.username="",.elevage_id=0,.type="CDC",.number="CDC12345"};
+    LegalNumber n2={.id=2,.username="",.elevage_id=0,.type="AOE",.number="AOE12345"};
+    TEST_ASSERT_TRUE(legal_numbers_add(&n1));
+    TEST_ASSERT_TRUE(legal_numbers_add(&n2));
     animals_init();
     time_t now = time(NULL);
     Reptile r = {
@@ -116,6 +133,11 @@ TEST_CASE("scheduler compliance quota reached","[scheduler]")
 {
     db_set_key("");
     TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    legal_numbers_init();
+    LegalNumber n1={.id=1,.username="",.elevage_id=0,.type="CDC",.number="CDC12345"};
+    LegalNumber n2={.id=2,.username="",.elevage_id=0,.type="AOE",.number="AOE12345"};
+    TEST_ASSERT_TRUE(legal_numbers_add(&n1));
+    TEST_ASSERT_TRUE(legal_numbers_add(&n2));
     animals_init();
     time_t now = time(NULL);
     Reptile r = {


### PR DESCRIPTION
## Summary
- add `legal_numbers` component with CRUD helpers
- create `cdc_aoe_numbers` table
- use DB-driven lists in `legal.c`
- init legal numbers in main
- update tests for new helpers
- document how to update CDC/AOE numbers

## Testing
- `pytest -q` *(fails: no tests detected)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686008a1690083239848ea54404554aa