### PR TITLE
Add legal fields to animals DB

### DIFF
--- a/components/animals/animals.c
+++ b/components/animals/animals.c
@@ -1,6 +1,6 @@
 #include "animals.h"
-#include "esp_log.h"
 #include "db.h"
+#include "esp_log.h"
 #include <sqlite3.h>
 #include <string.h>
 
@@ -9,130 +9,142 @@ static const char *TAG = "animals";
 static Reptile animals[ANIMALS_MAX];
 static int animal_count = 0;
 
-void animals_init(void)
-{
-    animal_count = 0;
-    memset(animals, 0, sizeof(animals));
+void animals_init(void) {
+  animal_count = 0;
+  memset(animals, 0, sizeof(animals));
 
-    sqlite3_stmt *stmt = db_query("SELECT id,elevage_id,name,species,sex,birth_date,health,breeding_cycle FROM animals;");
-    if (stmt) {
-        while (sqlite3_step(stmt) == SQLITE_ROW && animal_count < ANIMALS_MAX) {
-            Reptile *r = &animals[animal_count++];
-            r->id = sqlite3_column_int(stmt, 0);
-            r->elevage_id = sqlite3_column_int(stmt, 1);
-            strncpy(r->name, (const char *)sqlite3_column_text(stmt, 2), sizeof(r->name) - 1);
-            strncpy(r->species, (const char *)sqlite3_column_text(stmt, 3), sizeof(r->species) - 1);
-            strncpy(r->sex, (const char *)sqlite3_column_text(stmt, 4), sizeof(r->sex) - 1);
-            strncpy(r->birth_date, (const char *)sqlite3_column_text(stmt, 5), sizeof(r->birth_date) - 1);
-            strncpy(r->health, (const char *)sqlite3_column_text(stmt, 6), sizeof(r->health) - 1);
-            strncpy(r->breeding_cycle, (const char *)sqlite3_column_text(stmt, 7), sizeof(r->breeding_cycle) - 1);
-            r->cdc_number[0] = '\0';
-            r->aoe_number[0] = '\0';
-            r->ifap_id[0] = '\0';
-            r->quota_limit = 0;
-            r->quota_used = 0;
-            r->cerfa_valid_until = 0;
-            r->cites_valid_until = 0;
-        }
-        sqlite3_finalize(stmt);
+  sqlite3_stmt *stmt =
+      db_query("SELECT "
+               "id,elevage_id,name,species,sex,birth_date,health,breeding_"
+               "cycle,cdc_number,aoe_number,ifap_id,quota_limit,quota_used,"
+               "cerfa_valid_until,cites_valid_until FROM animals;");
+  if (stmt) {
+    while (sqlite3_step(stmt) == SQLITE_ROW && animal_count < ANIMALS_MAX) {
+      Reptile *r = &animals[animal_count++];
+      r->id = sqlite3_column_int(stmt, 0);
+      r->elevage_id = sqlite3_column_int(stmt, 1);
+      strncpy(r->name, (const char *)sqlite3_column_text(stmt, 2),
+              sizeof(r->name) - 1);
+      strncpy(r->species, (const char *)sqlite3_column_text(stmt, 3),
+              sizeof(r->species) - 1);
+      strncpy(r->sex, (const char *)sqlite3_column_text(stmt, 4),
+              sizeof(r->sex) - 1);
+      strncpy(r->birth_date, (const char *)sqlite3_column_text(stmt, 5),
+              sizeof(r->birth_date) - 1);
+      strncpy(r->health, (const char *)sqlite3_column_text(stmt, 6),
+              sizeof(r->health) - 1);
+      strncpy(r->breeding_cycle, (const char *)sqlite3_column_text(stmt, 7),
+              sizeof(r->breeding_cycle) - 1);
+      strncpy(r->cdc_number, (const char *)sqlite3_column_text(stmt, 8),
+              sizeof(r->cdc_number) - 1);
+      strncpy(r->aoe_number, (const char *)sqlite3_column_text(stmt, 9),
+              sizeof(r->aoe_number) - 1);
+      strncpy(r->ifap_id, (const char *)sqlite3_column_text(stmt, 10),
+              sizeof(r->ifap_id) - 1);
+      r->quota_limit = sqlite3_column_int(stmt, 11);
+      r->quota_used = sqlite3_column_int(stmt, 12);
+      r->cerfa_valid_until = sqlite3_column_int(stmt, 13);
+      r->cites_valid_until = sqlite3_column_int(stmt, 14);
     }
+    sqlite3_finalize(stmt);
+  }
 
-    ESP_LOGI(TAG, "Initialisation des donnees animaux");
+  ESP_LOGI(TAG, "Initialisation des donnees animaux");
 }
 
-bool animals_add(const Reptile *r)
-{
-    if (animal_count >= ANIMALS_MAX || !r)
-        return false;
-    if (!db_exec("INSERT INTO animals(id,elevage_id,name,species,sex,birth_date,health,breeding_cycle) "
-                 "VALUES(%d,%d,'%s','%s','%s','%s','%s','%s');",
-                 r->id, r->elevage_id, r->name, r->species, r->sex, r->birth_date,
-                 r->health, r->breeding_cycle))
-        return false;
-    animals[animal_count] = *r;
-    animal_count++;
-    ESP_LOGI(TAG, "Ajout du reptile %d", r->id);
-    return true;
+bool animals_add(const Reptile *r) {
+  if (animal_count >= ANIMALS_MAX || !r)
+    return false;
+  if (!db_exec("INSERT INTO "
+               "animals(id,elevage_id,name,species,sex,birth_date,health,"
+               "breeding_cycle,cdc_number,aoe_number,ifap_id,quota_limit,quota_"
+               "used,cerfa_valid_until,cites_valid_until) "
+               "VALUES(%d,%d,'%s','%s','%s','%s','%s','%s','%s','%s','%s',%d,%"
+               "d,%d,%d);",
+               r->id, r->elevage_id, r->name, r->species, r->sex, r->birth_date,
+               r->health, r->breeding_cycle, r->cdc_number, r->aoe_number,
+               r->ifap_id, r->quota_limit, r->quota_used, r->cerfa_valid_until,
+               r->cites_valid_until))
+    return false;
+  animals[animal_count] = *r;
+  animal_count++;
+  ESP_LOGI(TAG, "Ajout du reptile %d", r->id);
+  return true;
 }
 
-static int find_index(int id)
-{
-    for (int i = 0; i < animal_count; ++i) {
-        if (animals[i].id == id)
-            return i;
-    }
-    return -1;
+static int find_index(int id) {
+  for (int i = 0; i < animal_count; ++i) {
+    if (animals[i].id == id)
+      return i;
+  }
+  return -1;
 }
 
-const Reptile *animals_get(int id)
-{
-    int idx = find_index(id);
-    if (idx >= 0)
-        return &animals[idx];
+const Reptile *animals_get(int id) {
+  int idx = find_index(id);
+  if (idx >= 0)
+    return &animals[idx];
+  return NULL;
+}
+
+bool animals_update(int id, const Reptile *r) {
+  int idx = find_index(id);
+  if (idx < 0 || !r)
+    return false;
+  if (!db_exec(
+          "UPDATE animals SET elevage_id=%d,name='%s',species='%s',sex='%s',"
+          "birth_date='%s',health='%s',breeding_cycle='%s',cdc_number='%s',aoe_"
+          "number='%s',ifap_id='%s',quota_limit=%d,quota_used=%d,cerfa_valid_"
+          "until=%d,cites_valid_until=%d WHERE id=%d;",
+          r->elevage_id, r->name, r->species, r->sex, r->birth_date, r->health,
+          r->breeding_cycle, r->cdc_number, r->aoe_number, r->ifap_id,
+          r->quota_limit, r->quota_used, r->cerfa_valid_until,
+          r->cites_valid_until, id))
+    return false;
+  animals[idx] = *r;
+  ESP_LOGI(TAG, "Mise a jour du reptile %d", id);
+  return true;
+}
+
+bool animals_delete(int id) {
+  int idx = find_index(id);
+  if (idx < 0)
+    return false;
+  if (!db_exec("DELETE FROM animals WHERE id=%d;", id))
+    return false;
+  for (int i = idx; i < animal_count - 1; ++i) {
+    animals[i] = animals[i + 1];
+  }
+  animal_count--;
+  ESP_LOGI(TAG, "Suppression du reptile %d", id);
+  return true;
+}
+
+int animals_count(void) { return animal_count; }
+
+const Reptile *animals_get_by_index(int index) {
+  if (index < 0 || index >= animal_count)
     return NULL;
+  return &animals[index];
 }
 
-bool animals_update(int id, const Reptile *r)
-{
-    int idx = find_index(id);
-    if (idx < 0 || !r)
-        return false;
-    if (!db_exec("UPDATE animals SET elevage_id=%d,name='%s',species='%s',sex='%s'," 
-                 "birth_date='%s',health='%s',breeding_cycle='%s' WHERE id=%d;",
-                 r->elevage_id, r->name, r->species, r->sex, r->birth_date,
-                 r->health, r->breeding_cycle, id))
-        return false;
-    animals[idx] = *r;
-    ESP_LOGI(TAG, "Mise a jour du reptile %d", id);
-    return true;
+int animals_count_for_elevage(int elevage_id) {
+  int count = 0;
+  for (int i = 0; i < animal_count; ++i) {
+    if (animals[i].elevage_id == elevage_id)
+      count++;
+  }
+  return count;
 }
 
-bool animals_delete(int id)
-{
-    int idx = find_index(id);
-    if (idx < 0)
-        return false;
-    if (!db_exec("DELETE FROM animals WHERE id=%d;", id))
-        return false;
-    for (int i = idx; i < animal_count - 1; ++i) {
-        animals[i] = animals[i + 1];
+const Reptile *animals_get_by_index_for_elevage(int index, int elevage_id) {
+  int current = 0;
+  for (int i = 0; i < animal_count; ++i) {
+    if (animals[i].elevage_id == elevage_id) {
+      if (current == index)
+        return &animals[i];
+      current++;
     }
-    animal_count--;
-    ESP_LOGI(TAG, "Suppression du reptile %d", id);
-    return true;
-}
-
-int animals_count(void)
-{
-    return animal_count;
-}
-
-const Reptile *animals_get_by_index(int index)
-{
-    if (index < 0 || index >= animal_count)
-        return NULL;
-    return &animals[index];
-}
-
-int animals_count_for_elevage(int elevage_id)
-{
-    int count = 0;
-    for (int i = 0; i < animal_count; ++i) {
-        if (animals[i].elevage_id == elevage_id)
-            count++;
-    }
-    return count;
-}
-
-const Reptile *animals_get_by_index_for_elevage(int index, int elevage_id)
-{
-    int current = 0;
-    for (int i = 0; i < animal_count; ++i) {
-        if (animals[i].elevage_id == elevage_id) {
-            if (current == index)
-                return &animals[i];
-            current++;
-        }
-    }
-    return NULL;
+  }
+  return NULL;
 }

--- a/components/db/db.c
+++ b/components/db/db.c
@@ -1,519 +1,574 @@
 #include "db.h"
 #include "esp_log.h"
-#include "storage.h"
 #include "nvs.h"
 #include "nvs_flash.h"
+#include "sdkconfig.h"
+#include "storage.h"
 #include <sqlite3.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdarg.h>
-#include "sdkconfig.h"
 
 static const char *TAG = "db";
 static sqlite3 *db_handle = NULL;
 static char db_key[64];
 
-static bool open_db(const char *path)
-{
-    if (sqlite3_open(path, &db_handle) != SQLITE_OK) {
-        ESP_LOGE(TAG, "Impossible d'ouvrir la base de données: %s", sqlite3_errmsg(db_handle));
-        return false;
-    }
+static bool open_db(const char *path) {
+  if (sqlite3_open(path, &db_handle) != SQLITE_OK) {
+    ESP_LOGE(TAG, "Impossible d'ouvrir la base de données: %s",
+             sqlite3_errmsg(db_handle));
+    return false;
+  }
 #ifdef SQLITE_HAS_CODEC
-    if (db_key[0] != '\0') {
-        sqlite3_key(db_handle, db_key, strlen(db_key));
-    }
+  if (db_key[0] != '\0') {
+    sqlite3_key(db_handle, db_key, strlen(db_key));
+  }
 #endif
-    return true;
+  return true;
 }
 
-static void create_tables(void)
-{
-    exec_simple("CREATE TABLE IF NOT EXISTS elevages(""
-                "id INTEGER PRIMARY KEY,""
-                "name TEXT,""
-                "description TEXT);");
+static void create_tables(void) {
+  exec_simple("CREATE TABLE IF NOT EXISTS elevages("
+              "
+              "id INTEGER PRIMARY KEY,"
+              "
+              "name TEXT,"
+              "
+              "description TEXT);");
 
-    exec_simple("CREATE TABLE IF NOT EXISTS animals(""
-                "id INTEGER PRIMARY KEY,""
-                "elevage_id INTEGER,""
-                "name TEXT,""
-                "species TEXT,""
-                "sex TEXT,""
-                "birth_date TEXT,""
-                "health TEXT,""
-                "breeding_cycle TEXT);");
+  exec_simple("CREATE TABLE IF NOT EXISTS animals("
+              "
+              "id INTEGER PRIMARY KEY,"
+              "
+              "elevage_id INTEGER,"
+              "
+              "name TEXT,"
+              "
+              "species TEXT,"
+              "
+              "sex TEXT,"
+              "
+              "birth_date TEXT,"
+              "
+              "health TEXT,"
+              "
+              "breeding_cycle TEXT,"
+              "
+              "cdc_number TEXT,"
+              "
+              "aoe_number TEXT,"
+              "
+              "ifap_id TEXT,"
+              "
+              "quota_limit INTEGER,"
+              "
+              "quota_used INTEGER,"
+              "
+              "cerfa_valid_until INTEGER,"
+              "
+              "cites_valid_until INTEGER);");
 
-    exec_simple("CREATE TABLE IF NOT EXISTS terrariums(""
-                "id INTEGER PRIMARY KEY,""
-                "elevage_id INTEGER,""
-                "name TEXT,""
-                "capacity INTEGER,""
-                "inventory TEXT,""
-                "notes TEXT);");
+  exec_simple("CREATE TABLE IF NOT EXISTS terrariums("
+              "
+              "id INTEGER PRIMARY KEY,"
+              "
+              "elevage_id INTEGER,"
+              "
+              "name TEXT,"
+              "
+              "capacity INTEGER,"
+              "
+              "inventory TEXT,"
+              "
+              "notes TEXT);");
 
-    exec_simple("CREATE TABLE IF NOT EXISTS terrarium_logs(""
-                "id INTEGER PRIMARY KEY AUTOINCREMENT,""
-                "terrarium_id INTEGER,""
-                "message TEXT,""
-                "timestamp INTEGER DEFAULT (strftime('%s','now')));");
+  exec_simple("CREATE TABLE IF NOT EXISTS terrarium_logs("
+              "
+              "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+              "
+              "terrarium_id INTEGER,"
+              "
+              "message TEXT,"
+              "
+              "timestamp INTEGER DEFAULT (strftime('%s','now')));");
 
-    exec_simple("CREATE TABLE IF NOT EXISTS stocks(""
-                "id INTEGER PRIMARY KEY,""
-                "name TEXT,""
-                "quantity INTEGER,""
-                "min_quantity INTEGER);");
+  exec_simple("CREATE TABLE IF NOT EXISTS stocks("
+              "
+              "id INTEGER PRIMARY KEY,"
+              "
+              "name TEXT,"
+              "
+              "quantity INTEGER,"
+              "
+              "min_quantity INTEGER);");
 
-    exec_simple("CREATE TABLE IF NOT EXISTS transactions(""
-                "id INTEGER PRIMARY KEY AUTOINCREMENT,""
-                "stock_id INTEGER,""
-                "quantity INTEGER,""
-                "type TEXT,""
-                "timestamp INTEGER DEFAULT (strftime('%s','now')));");
-    exec_simple("CREATE TABLE IF NOT EXISTS users(""
-                "username TEXT PRIMARY KEY,""
-                "hash TEXT,""
-                "role INTEGER);");
+  exec_simple("CREATE TABLE IF NOT EXISTS transactions("
+              "
+              "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+              "
+              "stock_id INTEGER,"
+              "
+              "quantity INTEGER,"
+              "
+              "type TEXT,"
+              "
+              "timestamp INTEGER DEFAULT (strftime('%s','now')));");
+  exec_simple("CREATE TABLE IF NOT EXISTS users("
+              "
+              "username TEXT PRIMARY KEY,"
+              "
+              "hash TEXT,"
+              "
+              "role INTEGER);");
 
-    exec_simple("CREATE TABLE IF NOT EXISTS user_elevages(""
-                "username TEXT,""
-                "elevage_id INTEGER);");
-    exec_simple("CREATE TABLE IF NOT EXISTS health_records("""
-                "id INTEGER PRIMARY KEY,"""
-                "animal_id INTEGER,"""
-                "description TEXT,"""
-                "date INTEGER);");
+  exec_simple("CREATE TABLE IF NOT EXISTS user_elevages("
+              "
+              "username TEXT,"
+              "
+              "elevage_id INTEGER);");
+  exec_simple("CREATE TABLE IF NOT EXISTS health_records("
+              ""
+              "id INTEGER PRIMARY KEY,"
+              ""
+              "animal_id INTEGER,"
+              ""
+              "description TEXT,"
+              ""
+              "date INTEGER);");
 
-    exec_simple("CREATE TABLE IF NOT EXISTS breeding_events("""
-                "id INTEGER PRIMARY KEY,"""
-                "animal_id INTEGER,"""
-                "description TEXT,"""
-                "date INTEGER);");
+  exec_simple("CREATE TABLE IF NOT EXISTS breeding_events("
+              ""
+              "id INTEGER PRIMARY KEY,"
+              ""
+              "animal_id INTEGER,"
+              ""
+              "description TEXT,"
+              ""
+              "date INTEGER);");
 
-    exec_simple("CREATE TABLE IF NOT EXISTS cdc_aoe_numbers("""
-                "id INTEGER PRIMARY KEY,"""
-                "username TEXT,"""
-                "elevage_id INTEGER,"""
-                "type TEXT,"""
-                "number TEXT);");
+  exec_simple("CREATE TABLE IF NOT EXISTS cdc_aoe_numbers("
+              ""
+              "id INTEGER PRIMARY KEY,"
+              ""
+              "username TEXT,"
+              ""
+              "elevage_id INTEGER,"
+              ""
+              "type TEXT,"
+              ""
+              "number TEXT);");
 }
 
-static void load_db_key(void)
-{
-    nvs_handle_t h;
-    size_t len = sizeof(db_key);
-    if (nvs_open("db", NVS_READONLY, &h) == ESP_OK) {
-        if (nvs_get_str(h, "key", db_key, &len) != ESP_OK) {
-            db_key[0] = '\0';
-        }
-        nvs_close(h);
-    } else {
-        db_key[0] = '\0';
+static void load_db_key(void) {
+  nvs_handle_t h;
+  size_t len = sizeof(db_key);
+  if (nvs_open("db", NVS_READONLY, &h) == ESP_OK) {
+    if (nvs_get_str(h, "key", db_key, &len) != ESP_OK) {
+      db_key[0] = '\0';
     }
+    nvs_close(h);
+  } else {
+    db_key[0] = '\0';
+  }
 
 #ifdef CONFIG_DB_DEFAULT_KEY
-    if (db_key[0] == '\0' && strlen(CONFIG_DB_DEFAULT_KEY) > 0) {
-        strncpy(db_key, CONFIG_DB_DEFAULT_KEY, sizeof(db_key) - 1);
-        db_key[sizeof(db_key) - 1] = '\0';
-    }
-#endif
-}
-
-bool db_set_key(const char *key)
-{
-    if (!key)
-        return false;
-    strncpy(db_key, key, sizeof(db_key) - 1);
+  if (db_key[0] == '\0' && strlen(CONFIG_DB_DEFAULT_KEY) > 0) {
+    strncpy(db_key, CONFIG_DB_DEFAULT_KEY, sizeof(db_key) - 1);
     db_key[sizeof(db_key) - 1] = '\0';
-    nvs_handle_t h;
-    if (nvs_open("db", NVS_READWRITE, &h) != ESP_OK)
-        return false;
-    esp_err_t err = nvs_set_str(h, "key", db_key);
-    if (err == ESP_OK)
-        err = nvs_commit(h);
-    nvs_close(h);
-    return err == ESP_OK;
+  }
+#endif
 }
 
-static void exec_simple(const char *sql)
-{
-    char *err = NULL;
-    if (sqlite3_exec(db_handle, sql, NULL, NULL, &err) != SQLITE_OK) {
-        ESP_LOGE(TAG, "SQL error: %s", err ? err : "unknown");
-        sqlite3_free(err);
-    }
+bool db_set_key(const char *key) {
+  if (!key)
+    return false;
+  strncpy(db_key, key, sizeof(db_key) - 1);
+  db_key[sizeof(db_key) - 1] = '\0';
+  nvs_handle_t h;
+  if (nvs_open("db", NVS_READWRITE, &h) != ESP_OK)
+    return false;
+  esp_err_t err = nvs_set_str(h, "key", db_key);
+  if (err == ESP_OK)
+    err = nvs_commit(h);
+  nvs_close(h);
+  return err == ESP_OK;
 }
 
-bool db_exec(const char *format, ...)
-{
-    char sql[256];
-    va_list args;
-    va_start(args, format);
-    vsnprintf(sql, sizeof(sql), format, args);
-    va_end(args);
-
-    char *err = NULL;
-    if (sqlite3_exec(db_handle, sql, NULL, NULL, &err) != SQLITE_OK) {
-        ESP_LOGE(TAG, "SQL exec error: %s", err ? err : "unknown");
-        sqlite3_free(err);
-        return false;
-    }
-    return true;
+static void exec_simple(const char *sql) {
+  char *err = NULL;
+  if (sqlite3_exec(db_handle, sql, NULL, NULL, &err) != SQLITE_OK) {
+    ESP_LOGE(TAG, "SQL error: %s", err ? err : "unknown");
+    sqlite3_free(err);
+  }
 }
 
-sqlite3_stmt *db_query(const char *format, ...)
-{
-    char sql[256];
-    va_list args;
-    va_start(args, format);
-    vsnprintf(sql, sizeof(sql), format, args);
-    va_end(args);
+bool db_exec(const char *format, ...) {
+  char sql[256];
+  va_list args;
+  va_start(args, format);
+  vsnprintf(sql, sizeof(sql), format, args);
+  va_end(args);
 
-    sqlite3_stmt *stmt = NULL;
-    if (sqlite3_prepare_v2(db_handle, sql, -1, &stmt, NULL) != SQLITE_OK) {
-        ESP_LOGE(TAG, "SQL query error: %s", sqlite3_errmsg(db_handle));
-        return NULL;
-    }
-    return stmt;
+  char *err = NULL;
+  if (sqlite3_exec(db_handle, sql, NULL, NULL, &err) != SQLITE_OK) {
+    ESP_LOGE(TAG, "SQL exec error: %s", err ? err : "unknown");
+    sqlite3_free(err);
+    return false;
+  }
+  return true;
 }
 
-bool db_open_custom(const char *path)
-{
-    if (!open_db(path))
-        return false;
-    create_tables();
-    return true;
+sqlite3_stmt *db_query(const char *format, ...) {
+  char sql[256];
+  va_list args;
+  va_start(args, format);
+  vsnprintf(sql, sizeof(sql), format, args);
+  va_end(args);
+
+  sqlite3_stmt *stmt = NULL;
+  if (sqlite3_prepare_v2(db_handle, sql, -1, &stmt, NULL) != SQLITE_OK) {
+    ESP_LOGE(TAG, "SQL query error: %s", sqlite3_errmsg(db_handle));
+    return NULL;
+  }
+  return stmt;
 }
 
-void db_close(void)
-{
-    if (db_handle) {
-        sqlite3_close(db_handle);
-        db_handle = NULL;
-    }
+bool db_open_custom(const char *path) {
+  if (!open_db(path))
+    return false;
+  create_tables();
+  return true;
 }
 
-void db_init(void)
-{
-    ESP_LOGI(TAG, "Initialisation de la base de données");
+void db_close(void) {
+  if (db_handle) {
+    sqlite3_close(db_handle);
+    db_handle = NULL;
+  }
+}
 
-    load_db_key();
-    if (db_key[0] == '\0') {
-        char buf[64];
-        printf("Mot de passe BD: ");
-        fflush(stdout);
-        if (fgets(buf, sizeof(buf), stdin)) {
-            buf[strcspn(buf, "\r\n")] = '\0';
-            db_set_key(buf);
-        }
-    }
+void db_init(void) {
+  ESP_LOGI(TAG, "Initialisation de la base de données");
 
-    if (sqlite3_open("/spiffs/lizard.db", &db_handle) != SQLITE_OK) {
-        ESP_LOGE(TAG, "Impossible d'ouvrir la base de données: %s", sqlite3_errmsg(db_handle));
-        return;
+  load_db_key();
+  if (db_key[0] == '\0') {
+    char buf[64];
+    printf("Mot de passe BD: ");
+    fflush(stdout);
+    if (fgets(buf, sizeof(buf), stdin)) {
+      buf[strcspn(buf, "\r\n")] = '\0';
+      db_set_key(buf);
     }
+  }
+
+  if (sqlite3_open("/spiffs/lizard.db", &db_handle) != SQLITE_OK) {
+    ESP_LOGE(TAG, "Impossible d'ouvrir la base de données: %s",
+             sqlite3_errmsg(db_handle));
+    return;
+  }
 #ifdef SQLITE_HAS_CODEC
-    if (db_key[0] != '\0') {
-        sqlite3_key(db_handle, db_key, strlen(db_key));
-    }
+  if (db_key[0] != '\0') {
+    sqlite3_key(db_handle, db_key, strlen(db_key));
+  }
 #endif
 
-    create_tables();
+  create_tables();
 }
 
-void db_backup(void)
-{
-    ESP_LOGI(TAG, "Sauvegarde de la base de données");
+void db_backup(void) {
+  ESP_LOGI(TAG, "Sauvegarde de la base de données");
 
-    if (!db_handle)
-        return;
+  if (!db_handle)
+    return;
 
-    sqlite3 *backup_db = NULL;
-    if (sqlite3_open("/sdcard/lizard_backup.db", &backup_db) != SQLITE_OK) {
-        ESP_LOGE(TAG, "Erreur ouverture fichier backup");
-        return;
-    }
+  sqlite3 *backup_db = NULL;
+  if (sqlite3_open("/sdcard/lizard_backup.db", &backup_db) != SQLITE_OK) {
+    ESP_LOGE(TAG, "Erreur ouverture fichier backup");
+    return;
+  }
 
-    sqlite3_backup *backup = sqlite3_backup_init(backup_db, "main", db_handle, "main");
-    if (backup) {
-        sqlite3_backup_step(backup, -1);
-        sqlite3_backup_finish(backup);
-    }
-    sqlite3_close(backup_db);
-    storage_encrypt_file("/sdcard/lizard_backup.db");
+  sqlite3_backup *backup =
+      sqlite3_backup_init(backup_db, "main", db_handle, "main");
+  if (backup) {
+    sqlite3_backup_step(backup, -1);
+    sqlite3_backup_finish(backup);
+  }
+  sqlite3_close(backup_db);
+  storage_encrypt_file("/sdcard/lizard_backup.db");
 }
 
-static void export_elevages_csv(FILE *f)
-{
-    fprintf(f, "elevages\n");
-    fprintf(f, "id,name,description\n");
+static void export_elevages_csv(FILE *f) {
+  fprintf(f, "elevages\n");
+  fprintf(f, "id,name,description\n");
 
-    sqlite3_stmt *stmt;
-    if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,name,description FROM elevages;",
-                           -1, &stmt, NULL) == SQLITE_OK) {
-        while (sqlite3_step(stmt) == SQLITE_ROW) {
-            fprintf(f, "%d,%s,%s\n",
-                    sqlite3_column_int(stmt, 0),
-                    sqlite3_column_text(stmt, 1),
-                    sqlite3_column_text(stmt, 2));
-        }
-        sqlite3_finalize(stmt);
+  sqlite3_stmt *stmt;
+  if (sqlite3_prepare_v2(db_handle, "SELECT id,name,description FROM elevages;",
+                         -1, &stmt, NULL) == SQLITE_OK) {
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      fprintf(f, "%d,%s,%s\n", sqlite3_column_int(stmt, 0),
+              sqlite3_column_text(stmt, 1), sqlite3_column_text(stmt, 2));
     }
-    fprintf(f, "\n");
+    sqlite3_finalize(stmt);
+  }
+  fprintf(f, "\n");
 }
 
-static void export_animals_csv(FILE *f)
-{
-    fprintf(f, "animals\n");
-    fprintf(f, "id,elevage_id,name,species,sex,birth_date,health,breeding_cycle\n");
+static void export_animals_csv(FILE *f) {
+  fprintf(f, "animals\n");
+  fprintf(f, "id,elevage_id,name,species,sex,birth_date,health,breeding_cycle,"
+             "cdc_number,aoe_number,ifap_id,quota_limit,quota_used,cerfa_valid_"
+             "until,cites_valid_until\n");
 
-    sqlite3_stmt *stmt;
-    if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,elevage_id,name,species,sex,birth_date,health,breeding_cycle FROM animals;",
-                           -1, &stmt, NULL) == SQLITE_OK) {
-        while (sqlite3_step(stmt) == SQLITE_ROW) {
-            fprintf(f, "%d,%d,%s,%s,%s,%s,%s,%s\n",
-                    sqlite3_column_int(stmt, 0),
-                    sqlite3_column_int(stmt, 1),
-                    sqlite3_column_text(stmt, 2),
-                    sqlite3_column_text(stmt, 3),
-                    sqlite3_column_text(stmt, 4),
-                    sqlite3_column_text(stmt, 5),
-                    sqlite3_column_text(stmt, 6),
-                    sqlite3_column_text(stmt, 7));
-        }
-        sqlite3_finalize(stmt);
+  sqlite3_stmt *stmt;
+  if (sqlite3_prepare_v2(
+          db_handle,
+          "SELECT "
+          "id,elevage_id,name,species,sex,birth_date,health,breeding_cycle,cdc_"
+          "number,aoe_number,ifap_id,quota_limit,quota_used,cerfa_valid_until,"
+          "cites_valid_until FROM animals;",
+          -1, &stmt, NULL) == SQLITE_OK) {
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      fprintf(f, "%d,%d,%s,%s,%s,%s,%s,%s,%s,%s,%s,%d,%d,%d,%d\n",
+              sqlite3_column_int(stmt, 0), sqlite3_column_int(stmt, 1),
+              sqlite3_column_text(stmt, 2), sqlite3_column_text(stmt, 3),
+              sqlite3_column_text(stmt, 4), sqlite3_column_text(stmt, 5),
+              sqlite3_column_text(stmt, 6), sqlite3_column_text(stmt, 7),
+              sqlite3_column_text(stmt, 8), sqlite3_column_text(stmt, 9),
+              sqlite3_column_text(stmt, 10), sqlite3_column_int(stmt, 11),
+              sqlite3_column_int(stmt, 12), sqlite3_column_int(stmt, 13),
+              sqlite3_column_int(stmt, 14));
     }
-    fprintf(f, "\n");
+    sqlite3_finalize(stmt);
+  }
+  fprintf(f, "\n");
 }
 
-static void export_terrariums_csv(FILE *f)
-{
-    fprintf(f, "terrariums\n");
-    fprintf(f, "id,elevage_id,name,capacity,inventory,notes\n");
+static void export_terrariums_csv(FILE *f) {
+  fprintf(f, "terrariums\n");
+  fprintf(f, "id,elevage_id,name,capacity,inventory,notes\n");
 
-    sqlite3_stmt *stmt;
-    if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,elevage_id,name,capacity,inventory,notes FROM terrariums;",
-                           -1, &stmt, NULL) == SQLITE_OK) {
-        while (sqlite3_step(stmt) == SQLITE_ROW) {
-            fprintf(f, "%d,%d,%s,%d,%s,%s\n",
-                    sqlite3_column_int(stmt, 0),
-                    sqlite3_column_int(stmt, 1),
-                    sqlite3_column_text(stmt, 2),
-                    sqlite3_column_int(stmt, 3),
-                    sqlite3_column_text(stmt, 4),
-                    sqlite3_column_text(stmt, 5));
-        }
-        sqlite3_finalize(stmt);
+  sqlite3_stmt *stmt;
+  if (sqlite3_prepare_v2(
+          db_handle,
+          "SELECT id,elevage_id,name,capacity,inventory,notes FROM terrariums;",
+          -1, &stmt, NULL) == SQLITE_OK) {
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      fprintf(f, "%d,%d,%s,%d,%s,%s\n", sqlite3_column_int(stmt, 0),
+              sqlite3_column_int(stmt, 1), sqlite3_column_text(stmt, 2),
+              sqlite3_column_int(stmt, 3), sqlite3_column_text(stmt, 4),
+              sqlite3_column_text(stmt, 5));
     }
-    fprintf(f, "\n");
+    sqlite3_finalize(stmt);
+  }
+  fprintf(f, "\n");
 }
 
-static void export_stocks_csv(FILE *f)
-{
-    fprintf(f, "stocks\n");
-    fprintf(f, "id,name,quantity,min_quantity\n");
+static void export_stocks_csv(FILE *f) {
+  fprintf(f, "stocks\n");
+  fprintf(f, "id,name,quantity,min_quantity\n");
 
-    sqlite3_stmt *stmt;
-    if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,name,quantity,min_quantity FROM stocks;",
-                           -1, &stmt, NULL) == SQLITE_OK) {
-        while (sqlite3_step(stmt) == SQLITE_ROW) {
-            fprintf(f, "%d,%s,%d,%d\n",
-                    sqlite3_column_int(stmt, 0),
-                    sqlite3_column_text(stmt, 1),
-                    sqlite3_column_int(stmt, 2),
-                    sqlite3_column_int(stmt, 3));
-        }
-        sqlite3_finalize(stmt);
+  sqlite3_stmt *stmt;
+  if (sqlite3_prepare_v2(db_handle,
+                         "SELECT id,name,quantity,min_quantity FROM stocks;",
+                         -1, &stmt, NULL) == SQLITE_OK) {
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      fprintf(f, "%d,%s,%d,%d\n", sqlite3_column_int(stmt, 0),
+              sqlite3_column_text(stmt, 1), sqlite3_column_int(stmt, 2),
+              sqlite3_column_int(stmt, 3));
     }
-    fprintf(f, "\n");
+    sqlite3_finalize(stmt);
+  }
+  fprintf(f, "\n");
 }
 
-static void export_transactions_csv(FILE *f)
-{
-    fprintf(f, "transactions\n");
-    fprintf(f, "id,stock_id,quantity,type,timestamp\n");
+static void export_transactions_csv(FILE *f) {
+  fprintf(f, "transactions\n");
+  fprintf(f, "id,stock_id,quantity,type,timestamp\n");
 
-    sqlite3_stmt *stmt;
-    if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,stock_id,quantity,type,timestamp FROM transactions;",
-                           -1, &stmt, NULL) == SQLITE_OK) {
-        while (sqlite3_step(stmt) == SQLITE_ROW) {
-            fprintf(f, "%d,%d,%d,%s,%d\n",
-                    sqlite3_column_int(stmt, 0),
-                    sqlite3_column_int(stmt, 1),
-                    sqlite3_column_int(stmt, 2),
-                    sqlite3_column_text(stmt, 3),
-                    sqlite3_column_int(stmt, 4));
-        }
-        sqlite3_finalize(stmt);
+  sqlite3_stmt *stmt;
+  if (sqlite3_prepare_v2(
+          db_handle,
+          "SELECT id,stock_id,quantity,type,timestamp FROM transactions;", -1,
+          &stmt, NULL) == SQLITE_OK) {
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      fprintf(f, "%d,%d,%d,%s,%d\n", sqlite3_column_int(stmt, 0),
+              sqlite3_column_int(stmt, 1), sqlite3_column_int(stmt, 2),
+              sqlite3_column_text(stmt, 3), sqlite3_column_int(stmt, 4));
     }
-    fprintf(f, "\n");
+    sqlite3_finalize(stmt);
+  }
+  fprintf(f, "\n");
 }
 
-static void export_elevages_json(FILE *f)
-{
-    fprintf(f, "  \"elevages\": [\n");
-    sqlite3_stmt *stmt;
-    bool first = true;
-    if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,name,description FROM elevages;",
-                           -1, &stmt, NULL) == SQLITE_OK) {
-        while (sqlite3_step(stmt) == SQLITE_ROW) {
-            if (!first) fprintf(f, ",\n");
-            first = false;
-            fprintf(f, "    {\"id\":%d,\"name\":\"%s\",\"description\":\"%s\"}",
-                    sqlite3_column_int(stmt, 0),
-                    sqlite3_column_text(stmt, 1),
-                    sqlite3_column_text(stmt, 2));
-        }
-        sqlite3_finalize(stmt);
+static void export_elevages_json(FILE *f) {
+  fprintf(f, "  \"elevages\": [\n");
+  sqlite3_stmt *stmt;
+  bool first = true;
+  if (sqlite3_prepare_v2(db_handle, "SELECT id,name,description FROM elevages;",
+                         -1, &stmt, NULL) == SQLITE_OK) {
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      if (!first)
+        fprintf(f, ",\n");
+      first = false;
+      fprintf(f, "    {\"id\":%d,\"name\":\"%s\",\"description\":\"%s\"}",
+              sqlite3_column_int(stmt, 0), sqlite3_column_text(stmt, 1),
+              sqlite3_column_text(stmt, 2));
     }
-    fprintf(f, "\n  ],\n");
+    sqlite3_finalize(stmt);
+  }
+  fprintf(f, "\n  ],\n");
 }
 
-void db_export_csv(const char *path)
-{
-    if (!db_handle || !path)
-        return;
+void db_export_csv(const char *path) {
+  if (!db_handle || !path)
+    return;
 
-    FILE *f = fopen(path, "w");
-    if (!f) {
-        ESP_LOGE(TAG, "Impossible d'ouvrir %s", path);
-        return;
-    }
+  FILE *f = fopen(path, "w");
+  if (!f) {
+    ESP_LOGE(TAG, "Impossible d'ouvrir %s", path);
+    return;
+  }
 
-    export_elevages_csv(f);
-    export_animals_csv(f);
-    export_terrariums_csv(f);
-    export_stocks_csv(f);
-    export_transactions_csv(f);
+  export_elevages_csv(f);
+  export_animals_csv(f);
+  export_terrariums_csv(f);
+  export_stocks_csv(f);
+  export_transactions_csv(f);
 
-    fclose(f);
-    ESP_LOGI(TAG, "Export CSV vers %s termine", path);
+  fclose(f);
+  ESP_LOGI(TAG, "Export CSV vers %s termine", path);
 }
 
-static void export_animals_json(FILE *f)
-{
-    fprintf(f, "  \"animals\": [\n");
-    sqlite3_stmt *stmt;
-    bool first = true;
-    if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,elevage_id,name,species,sex,birth_date,health,breeding_cycle FROM animals;",
-                           -1, &stmt, NULL) == SQLITE_OK) {
-        while (sqlite3_step(stmt) == SQLITE_ROW) {
-            if (!first) fprintf(f, ",\n");
-            first = false;
-            fprintf(f, "    {\"id\":%d,\"elevage_id\":%d,\"name\":\"%s\",\"species\":\"%s\",\"sex\":\"%s\",\"birth_date\":\"%s\",\"health\":\"%s\",\"breeding_cycle\":\"%s\"}",
-                    sqlite3_column_int(stmt, 0),
-                    sqlite3_column_int(stmt, 1),
-                    sqlite3_column_text(stmt, 2),
-                    sqlite3_column_text(stmt, 3),
-                    sqlite3_column_text(stmt, 4),
-                    sqlite3_column_text(stmt, 5),
-                    sqlite3_column_text(stmt, 6),
-                    sqlite3_column_text(stmt, 7));
-        }
-        sqlite3_finalize(stmt);
+static void export_animals_json(FILE *f) {
+  fprintf(f, "  \"animals\": [\n");
+  sqlite3_stmt *stmt;
+  bool first = true;
+  if (sqlite3_prepare_v2(
+          db_handle,
+          "SELECT "
+          "id,elevage_id,name,species,sex,birth_date,health,breeding_cycle,cdc_"
+          "number,aoe_number,ifap_id,quota_limit,quota_used,cerfa_valid_until,"
+          "cites_valid_until FROM animals;",
+          -1, &stmt, NULL) == SQLITE_OK) {
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      if (!first)
+        fprintf(f, ",\n");
+      first = false;
+      fprintf(f,
+              "    "
+              "{\"id\":%d,\"elevage_id\":%d,\"name\":\"%s\",\"species\":\"%s\","
+              "\"sex\":\"%s\",\"birth_date\":\"%s\",\"health\":\"%s\","
+              "\"breeding_cycle\":\"%s\",\"cdc_number\":\"%s\",\"aoe_number\":"
+              "\"%s\",\"ifap_id\":\"%s\",\"quota_limit\":%d,\"quota_used\":%d,"
+              "\"cerfa_valid_until\":%d,\"cites_valid_until\":%d}",
+              sqlite3_column_int(stmt, 0), sqlite3_column_int(stmt, 1),
+              sqlite3_column_text(stmt, 2), sqlite3_column_text(stmt, 3),
+              sqlite3_column_text(stmt, 4), sqlite3_column_text(stmt, 5),
+              sqlite3_column_text(stmt, 6), sqlite3_column_text(stmt, 7),
+              sqlite3_column_text(stmt, 8), sqlite3_column_text(stmt, 9),
+              sqlite3_column_text(stmt, 10), sqlite3_column_int(stmt, 11),
+              sqlite3_column_int(stmt, 12), sqlite3_column_int(stmt, 13),
+              sqlite3_column_int(stmt, 14));
     }
-    fprintf(f, "\n  ],\n");
+    sqlite3_finalize(stmt);
+  }
+  fprintf(f, "\n  ],\n");
 }
 
-static void export_terrariums_json(FILE *f)
-{
-    fprintf(f, "  \"terrariums\": [\n");
-    sqlite3_stmt *stmt;
-    bool first = true;
-    if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,elevage_id,name,capacity,inventory,notes FROM terrariums;",
-                           -1, &stmt, NULL) == SQLITE_OK) {
-        while (sqlite3_step(stmt) == SQLITE_ROW) {
-            if (!first) fprintf(f, ",\n");
-            first = false;
-            fprintf(f, "    {\"id\":%d,\"elevage_id\":%d,\"name\":\"%s\",\"capacity\":%d,\"inventory\":\"%s\",\"notes\":\"%s\"}",
-                    sqlite3_column_int(stmt, 0),
-                    sqlite3_column_int(stmt, 1),
-                    sqlite3_column_text(stmt, 2),
-                    sqlite3_column_int(stmt, 3),
-                    sqlite3_column_text(stmt, 4),
-                    sqlite3_column_text(stmt, 5));
-        }
-        sqlite3_finalize(stmt);
+static void export_terrariums_json(FILE *f) {
+  fprintf(f, "  \"terrariums\": [\n");
+  sqlite3_stmt *stmt;
+  bool first = true;
+  if (sqlite3_prepare_v2(
+          db_handle,
+          "SELECT id,elevage_id,name,capacity,inventory,notes FROM terrariums;",
+          -1, &stmt, NULL) == SQLITE_OK) {
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      if (!first)
+        fprintf(f, ",\n");
+      first = false;
+      fprintf(f,
+              "    "
+              "{\"id\":%d,\"elevage_id\":%d,\"name\":\"%s\",\"capacity\":%d,"
+              "\"inventory\":\"%s\",\"notes\":\"%s\"}",
+              sqlite3_column_int(stmt, 0), sqlite3_column_int(stmt, 1),
+              sqlite3_column_text(stmt, 2), sqlite3_column_int(stmt, 3),
+              sqlite3_column_text(stmt, 4), sqlite3_column_text(stmt, 5));
     }
-    fprintf(f, "\n  ]\n");
+    sqlite3_finalize(stmt);
+  }
+  fprintf(f, "\n  ]\n");
 }
 
-static void export_stocks_json(FILE *f)
-{
-    fprintf(f, "  \"stocks\": [\n");
-    sqlite3_stmt *stmt;
-    bool first = true;
-    if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,name,quantity,min_quantity FROM stocks;",
-                           -1, &stmt, NULL) == SQLITE_OK) {
-        while (sqlite3_step(stmt) == SQLITE_ROW) {
-            if (!first) fprintf(f, ",\n");
-            first = false;
-            fprintf(f, "    {\"id\":%d,\"name\":\"%s\",\"quantity\":%d,\"min_quantity\":%d}",
-                    sqlite3_column_int(stmt, 0),
-                    sqlite3_column_text(stmt, 1),
-                    sqlite3_column_int(stmt, 2),
-                    sqlite3_column_int(stmt, 3));
-        }
-        sqlite3_finalize(stmt);
+static void export_stocks_json(FILE *f) {
+  fprintf(f, "  \"stocks\": [\n");
+  sqlite3_stmt *stmt;
+  bool first = true;
+  if (sqlite3_prepare_v2(db_handle,
+                         "SELECT id,name,quantity,min_quantity FROM stocks;",
+                         -1, &stmt, NULL) == SQLITE_OK) {
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      if (!first)
+        fprintf(f, ",\n");
+      first = false;
+      fprintf(
+          f,
+          "    {\"id\":%d,\"name\":\"%s\",\"quantity\":%d,\"min_quantity\":%d}",
+          sqlite3_column_int(stmt, 0), sqlite3_column_text(stmt, 1),
+          sqlite3_column_int(stmt, 2), sqlite3_column_int(stmt, 3));
     }
-    fprintf(f, "\n  ],\n");
+    sqlite3_finalize(stmt);
+  }
+  fprintf(f, "\n  ],\n");
 }
 
-static void export_transactions_json(FILE *f)
-{
-    fprintf(f, "  \"transactions\": [\n");
-    sqlite3_stmt *stmt;
-    bool first = true;
-    if (sqlite3_prepare_v2(db_handle,
-                           "SELECT id,stock_id,quantity,type,timestamp FROM transactions;",
-                           -1, &stmt, NULL) == SQLITE_OK) {
-        while (sqlite3_step(stmt) == SQLITE_ROW) {
-            if (!first) fprintf(f, ",\n");
-            first = false;
-            fprintf(f, "    {\"id\":%d,\"stock_id\":%d,\"quantity\":%d,\"type\":\"%s\",\"timestamp\":%d}",
-                    sqlite3_column_int(stmt, 0),
-                    sqlite3_column_int(stmt, 1),
-                    sqlite3_column_int(stmt, 2),
-                    sqlite3_column_text(stmt, 3),
-                    sqlite3_column_int(stmt, 4));
-        }
-        sqlite3_finalize(stmt);
+static void export_transactions_json(FILE *f) {
+  fprintf(f, "  \"transactions\": [\n");
+  sqlite3_stmt *stmt;
+  bool first = true;
+  if (sqlite3_prepare_v2(
+          db_handle,
+          "SELECT id,stock_id,quantity,type,timestamp FROM transactions;", -1,
+          &stmt, NULL) == SQLITE_OK) {
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      if (!first)
+        fprintf(f, ",\n");
+      first = false;
+      fprintf(f,
+              "    "
+              "{\"id\":%d,\"stock_id\":%d,\"quantity\":%d,\"type\":\"%s\","
+              "\"timestamp\":%d}",
+              sqlite3_column_int(stmt, 0), sqlite3_column_int(stmt, 1),
+              sqlite3_column_int(stmt, 2), sqlite3_column_text(stmt, 3),
+              sqlite3_column_int(stmt, 4));
     }
-    fprintf(f, "\n  ]\n");
+    sqlite3_finalize(stmt);
+  }
+  fprintf(f, "\n  ]\n");
 }
 
-void db_export_json(const char *path)
-{
-    if (!db_handle || !path)
-        return;
+void db_export_json(const char *path) {
+  if (!db_handle || !path)
+    return;
 
-    FILE *f = fopen(path, "w");
-    if (!f) {
-        ESP_LOGE(TAG, "Impossible d'ouvrir %s", path);
-        return;
-    }
+  FILE *f = fopen(path, "w");
+  if (!f) {
+    ESP_LOGE(TAG, "Impossible d'ouvrir %s", path);
+    return;
+  }
 
-    fprintf(f, "{\n");
-    export_elevages_json(f);
-    fprintf(f, ",\n");
-    export_animals_json(f);
-    fprintf(f, ",\n");
-    export_terrariums_json(f);
-    fprintf(f, ",\n");
-    export_stocks_json(f);
-    fprintf(f, ",\n");
-    export_transactions_json(f);
-    fprintf(f, "}\n");
+  fprintf(f, "{\n");
+  export_elevages_json(f);
+  fprintf(f, ",\n");
+  export_animals_json(f);
+  fprintf(f, ",\n");
+  export_terrariums_json(f);
+  fprintf(f, ",\n");
+  export_stocks_json(f);
+  fprintf(f, ",\n");
+  export_transactions_json(f);
+  fprintf(f, "}\n");
 
-    fclose(f);
-    ESP_LOGI(TAG, "Export JSON vers %s termine", path);
+  fclose(f);
+  ESP_LOGI(TAG, "Export JSON vers %s termine", path);
 }

--- a/tests/test_crud.c
+++ b/tests/test_crud.c
@@ -1,137 +1,151 @@
-#include "unity.h"
-#include "db.h"
 #include "animals.h"
-#include "terrariums.h"
-#include "stocks.h"
-#include "transactions.h"
-#include "health.h"
 #include "breeding.h"
+#include "db.h"
+#include "health.h"
 #include "legal_numbers.h"
+#include "stocks.h"
+#include "terrariums.h"
+#include "transactions.h"
+#include "unity.h"
 
-TEST_CASE("animals crud","[animals]")
-{
-    db_set_key("");
-    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
-    animals_init();
-    Reptile r = { .id = 1, .elevage_id = 1, .name = "Liz", .species="Lizard", .sex="F", .birth_date="2021", .health="ok", .breeding_cycle="" };
-    TEST_ASSERT_TRUE(animals_add(&r));
-    TEST_ASSERT_EQUAL_INT(1, animals_count());
-    const Reptile *g = animals_get(1);
-    TEST_ASSERT_NOT_NULL(g);
-    strcpy(r.health, "good");
-    TEST_ASSERT_TRUE(animals_update(1, &r));
-    g = animals_get(1);
-    TEST_ASSERT_EQUAL_STRING("good", g->health);
-    TEST_ASSERT_TRUE(animals_delete(1));
-    TEST_ASSERT_EQUAL_INT(0, animals_count());
-    db_close();
+TEST_CASE("animals crud", "[animals]") {
+  db_set_key("");
+  TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+  animals_init();
+  Reptile r = {.id = 1,
+               .elevage_id = 1,
+               .name = "Liz",
+               .species = "Lizard",
+               .sex = "F",
+               .birth_date = "2021",
+               .health = "ok",
+               .breeding_cycle = "",
+               .cdc_number = "",
+               .aoe_number = "",
+               .ifap_id = "",
+               .quota_limit = 0,
+               .quota_used = 0,
+               .cerfa_valid_until = 0,
+               .cites_valid_until = 0};
+  TEST_ASSERT_TRUE(animals_add(&r));
+  TEST_ASSERT_EQUAL_INT(1, animals_count());
+  const Reptile *g = animals_get(1);
+  TEST_ASSERT_NOT_NULL(g);
+  strcpy(r.health, "good");
+  TEST_ASSERT_TRUE(animals_update(1, &r));
+  g = animals_get(1);
+  TEST_ASSERT_EQUAL_STRING("good", g->health);
+  TEST_ASSERT_TRUE(animals_delete(1));
+  TEST_ASSERT_EQUAL_INT(0, animals_count());
+  db_close();
 }
 
-TEST_CASE("terrariums crud","[terrariums]")
-{
-    db_set_key("");
-    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
-    terrariums_init(0);
-    Terrarium t = { .id=1, .elevage_id=1, .name="T1", .capacity=2 };
-    TEST_ASSERT_TRUE(terrariums_add(&t));
-    const Terrarium *gt = terrariums_get(1);
-    TEST_ASSERT_NOT_NULL(gt);
-    t.capacity = 3;
-    TEST_ASSERT_TRUE(terrariums_update(1,&t));
-    gt = terrariums_get(1);
-    TEST_ASSERT_EQUAL_INT(3, gt->capacity);
-    TEST_ASSERT_TRUE(terrariums_delete(1));
-    TEST_ASSERT_NULL(terrariums_get(1));
-    db_close();
+TEST_CASE("terrariums crud", "[terrariums]") {
+  db_set_key("");
+  TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+  terrariums_init(0);
+  Terrarium t = {.id = 1, .elevage_id = 1, .name = "T1", .capacity = 2};
+  TEST_ASSERT_TRUE(terrariums_add(&t));
+  const Terrarium *gt = terrariums_get(1);
+  TEST_ASSERT_NOT_NULL(gt);
+  t.capacity = 3;
+  TEST_ASSERT_TRUE(terrariums_update(1, &t));
+  gt = terrariums_get(1);
+  TEST_ASSERT_EQUAL_INT(3, gt->capacity);
+  TEST_ASSERT_TRUE(terrariums_delete(1));
+  TEST_ASSERT_NULL(terrariums_get(1));
+  db_close();
 }
 
-TEST_CASE("stocks crud","[stocks]")
-{
-    db_set_key("");
-    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
-    stocks_init();
-    StockItem s = { .id=1, .name="Food", .quantity=5, .min_quantity=1 };
-    TEST_ASSERT_TRUE(stocks_add(&s));
-    const StockItem *gs = stocks_get(1);
-    TEST_ASSERT_NOT_NULL(gs);
-    s.quantity = 7;
-    TEST_ASSERT_TRUE(stocks_update(1,&s));
-    gs = stocks_get(1);
-    TEST_ASSERT_EQUAL_INT(7, gs->quantity);
-    TEST_ASSERT_TRUE(stocks_delete(1));
-    TEST_ASSERT_NULL(stocks_get(1));
-    db_close();
+TEST_CASE("stocks crud", "[stocks]") {
+  db_set_key("");
+  TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+  stocks_init();
+  StockItem s = {.id = 1, .name = "Food", .quantity = 5, .min_quantity = 1};
+  TEST_ASSERT_TRUE(stocks_add(&s));
+  const StockItem *gs = stocks_get(1);
+  TEST_ASSERT_NOT_NULL(gs);
+  s.quantity = 7;
+  TEST_ASSERT_TRUE(stocks_update(1, &s));
+  gs = stocks_get(1);
+  TEST_ASSERT_EQUAL_INT(7, gs->quantity);
+  TEST_ASSERT_TRUE(stocks_delete(1));
+  TEST_ASSERT_NULL(stocks_get(1));
+  db_close();
 }
 
-TEST_CASE("transactions crud","[transactions]")
-{
-    db_set_key("");
-    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
-    transactions_init();
-    Transaction tr = { .id=1, .stock_id=1, .quantity=2, .type=TRANSACTION_PURCHASE };
-    TEST_ASSERT_TRUE(transactions_add(&tr));
-    const Transaction *gt = transactions_get(1);
-    TEST_ASSERT_NOT_NULL(gt);
-    tr.quantity = 3;
-    TEST_ASSERT_TRUE(transactions_update(1,&tr));
-    gt = transactions_get(1);
-    TEST_ASSERT_EQUAL_INT(3, gt->quantity);
-    TEST_ASSERT_TRUE(transactions_delete(1));
-    TEST_ASSERT_NULL(transactions_get(1));
-    db_close();
+TEST_CASE("transactions crud", "[transactions]") {
+  db_set_key("");
+  TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+  transactions_init();
+  Transaction tr = {
+      .id = 1, .stock_id = 1, .quantity = 2, .type = TRANSACTION_PURCHASE};
+  TEST_ASSERT_TRUE(transactions_add(&tr));
+  const Transaction *gt = transactions_get(1);
+  TEST_ASSERT_NOT_NULL(gt);
+  tr.quantity = 3;
+  TEST_ASSERT_TRUE(transactions_update(1, &tr));
+  gt = transactions_get(1);
+  TEST_ASSERT_EQUAL_INT(3, gt->quantity);
+  TEST_ASSERT_TRUE(transactions_delete(1));
+  TEST_ASSERT_NULL(transactions_get(1));
+  db_close();
 }
 
-TEST_CASE("health records crud","[health]")
-{
-    db_set_key("");
-    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
-    health_init();
-    HealthRecord hr = { .id=1, .animal_id=1, .description="check", .date=0 };
-    TEST_ASSERT_TRUE(health_add(&hr));
-    const HealthRecord *gr = health_get(1);
-    TEST_ASSERT_NOT_NULL(gr);
-    strcpy(hr.description, "done");
-    TEST_ASSERT_TRUE(health_update(1, &hr));
-    gr = health_get(1);
-    TEST_ASSERT_EQUAL_STRING("done", gr->description);
-    TEST_ASSERT_TRUE(health_delete(1));
-    TEST_ASSERT_NULL(health_get(1));
-    db_close();
+TEST_CASE("health records crud", "[health]") {
+  db_set_key("");
+  TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+  health_init();
+  HealthRecord hr = {
+      .id = 1, .animal_id = 1, .description = "check", .date = 0};
+  TEST_ASSERT_TRUE(health_add(&hr));
+  const HealthRecord *gr = health_get(1);
+  TEST_ASSERT_NOT_NULL(gr);
+  strcpy(hr.description, "done");
+  TEST_ASSERT_TRUE(health_update(1, &hr));
+  gr = health_get(1);
+  TEST_ASSERT_EQUAL_STRING("done", gr->description);
+  TEST_ASSERT_TRUE(health_delete(1));
+  TEST_ASSERT_NULL(health_get(1));
+  db_close();
 }
 
-TEST_CASE("breeding events crud","[breeding]")
-{
-    db_set_key("");
-    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
-    breeding_init();
-    BreedingEvent ev = { .id=1, .animal_id=1, .description="pair", .date=0 };
-    TEST_ASSERT_TRUE(breeding_add(&ev));
-    const BreedingEvent *ge = breeding_get(1);
-    TEST_ASSERT_NOT_NULL(ge);
-    strcpy(ev.description, "laid");
-    TEST_ASSERT_TRUE(breeding_update(1, &ev));
-    ge = breeding_get(1);
-    TEST_ASSERT_EQUAL_STRING("laid", ge->description);
-    TEST_ASSERT_TRUE(breeding_delete(1));
-    TEST_ASSERT_NULL(breeding_get(1));
-    db_close();
+TEST_CASE("breeding events crud", "[breeding]") {
+  db_set_key("");
+  TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+  breeding_init();
+  BreedingEvent ev = {
+      .id = 1, .animal_id = 1, .description = "pair", .date = 0};
+  TEST_ASSERT_TRUE(breeding_add(&ev));
+  const BreedingEvent *ge = breeding_get(1);
+  TEST_ASSERT_NOT_NULL(ge);
+  strcpy(ev.description, "laid");
+  TEST_ASSERT_TRUE(breeding_update(1, &ev));
+  ge = breeding_get(1);
+  TEST_ASSERT_EQUAL_STRING("laid", ge->description);
+  TEST_ASSERT_TRUE(breeding_delete(1));
+  TEST_ASSERT_NULL(breeding_get(1));
+  db_close();
 }
 
-TEST_CASE("legal numbers crud","[legal_numbers]")
-{
-    db_set_key("");
-    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
-    legal_numbers_init();
-    LegalNumber n = { .id=1, .username="user", .elevage_id=0, .type="CDC", .number="CDC999" };
-    TEST_ASSERT_TRUE(legal_numbers_add(&n));
-    TEST_ASSERT_EQUAL_INT(1, legal_numbers_count());
-    const LegalNumber *gn = legal_numbers_get(1);
-    TEST_ASSERT_NOT_NULL(gn);
-    strcpy(n.number, "CDC888");
-    TEST_ASSERT_TRUE(legal_numbers_update(1,&n));
-    gn = legal_numbers_get(1);
-    TEST_ASSERT_EQUAL_STRING("CDC888", gn->number);
-    TEST_ASSERT_TRUE(legal_numbers_delete(1));
-    TEST_ASSERT_EQUAL_INT(0, legal_numbers_count());
-    db_close();
+TEST_CASE("legal numbers crud", "[legal_numbers]") {
+  db_set_key("");
+  TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+  legal_numbers_init();
+  LegalNumber n = {.id = 1,
+                   .username = "user",
+                   .elevage_id = 0,
+                   .type = "CDC",
+                   .number = "CDC999"};
+  TEST_ASSERT_TRUE(legal_numbers_add(&n));
+  TEST_ASSERT_EQUAL_INT(1, legal_numbers_count());
+  const LegalNumber *gn = legal_numbers_get(1);
+  TEST_ASSERT_NOT_NULL(gn);
+  strcpy(n.number, "CDC888");
+  TEST_ASSERT_TRUE(legal_numbers_update(1, &n));
+  gn = legal_numbers_get(1);
+  TEST_ASSERT_EQUAL_STRING("CDC888", gn->number);
+  TEST_ASSERT_TRUE(legal_numbers_delete(1));
+  TEST_ASSERT_EQUAL_INT(0, legal_numbers_count());
+  db_close();
 }


### PR DESCRIPTION
## Summary
- extend `animals` table with CDC/AOE, I-FAP and document data
- load/save the extra fields in animal CRUD helpers
- include the new columns in CSV/JSON export
- adjust CRUD tests for new structure

## Testing
- `make -C tests` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6860206b9c208323b5d14666875349e2