### PR TITLE
Add CSV import support

### DIFF
--- a/components/db/db.c
+++ b/components/db/db.c
@@ -572,3 +572,107 @@ void db_export_json(const char *path) {
   fclose(f);
   ESP_LOGI(TAG, "Export JSON vers %s termine", path);
 }
+
+static char *next_token(char **line)
+{
+  char *start = *line;
+  char *comma = strchr(start, ',');
+  if (comma) {
+    *comma = '\0';
+    *line = comma + 1;
+  } else {
+    *line = start + strlen(start);
+  }
+  return start;
+}
+
+static void clear_tables(void)
+{
+  exec_simple("DELETE FROM transactions;");
+  exec_simple("DELETE FROM stocks;");
+  exec_simple("DELETE FROM terrariums;");
+  exec_simple("DELETE FROM animals;");
+  exec_simple("DELETE FROM elevages;");
+}
+
+void db_import_csv(const char *path)
+{
+  if (!db_handle || !path)
+    return;
+
+  FILE *f = fopen(path, "r");
+  if (!f) {
+    ESP_LOGE(TAG, "Impossible d'ouvrir %s", path);
+    return;
+  }
+
+  sqlite3_exec(db_handle, "BEGIN TRANSACTION;", NULL, NULL, NULL);
+  clear_tables();
+
+  char line[512];
+  char table[32] = "";
+  while (fgets(line, sizeof(line), f)) {
+    line[strcspn(line, "\r\n")] = '\0';
+    if (line[0] == '\0') {
+      table[0] = '\0';
+      continue;
+    }
+
+    if (table[0] == '\0') {
+      strncpy(table, line, sizeof(table) - 1);
+      table[sizeof(table) - 1] = '\0';
+      fgets(line, sizeof(line), f); /* skip header */
+      continue;
+    }
+
+    char *ptr = line;
+    if (strcmp(table, "elevages") == 0) {
+      char *tok_id = next_token(&ptr);
+      char *name = next_token(&ptr);
+      char *desc = ptr;
+      db_exec("INSERT INTO elevages(id,name,description) VALUES(%d,'%s','%s');",
+              atoi(tok_id), name, desc);
+    } else if (strcmp(table, "animals") == 0) {
+      char *tok[15];
+      for (int i = 0; i < 14; ++i)
+        tok[i] = next_token(&ptr);
+      tok[14] = ptr;
+      db_exec("INSERT INTO animals(id,elevage_id,name,species,sex,birth_date,health,breeding_cycle,cdc_number,aoe_number,ifap_id,quota_limit,quota_used,cerfa_valid_until,cites_valid_until) "
+              "VALUES(%d,%d,'%s','%s','%s','%s','%s','%s','%s','%s','%s',%d,%d,%d,%d);",
+              atoi(tok[0]), atoi(tok[1]), tok[2], tok[3], tok[4], tok[5], tok[6],
+              tok[7], tok[8], tok[9], tok[10], atoi(tok[11]), atoi(tok[12]),
+              atoi(tok[13]), atoi(tok[14]));
+    } else if (strcmp(table, "terrariums") == 0) {
+      char *tok_id = next_token(&ptr);
+      char *tok_elev = next_token(&ptr);
+      char *name = next_token(&ptr);
+      char *cap = next_token(&ptr);
+      char *inv = next_token(&ptr);
+      char *notes = ptr;
+      db_exec(
+          "INSERT INTO terrariums(id,elevage_id,name,capacity,inventory,notes) "
+          "VALUES(%d,%d,'%s',%d,'%s','%s');",
+          atoi(tok_id), atoi(tok_elev), name, atoi(cap), inv, notes);
+    } else if (strcmp(table, "stocks") == 0) {
+      char *tok_id = next_token(&ptr);
+      char *name = next_token(&ptr);
+      char *qty = next_token(&ptr);
+      char *min = ptr;
+      db_exec("INSERT INTO stocks(id,name,quantity,min_quantity) VALUES(%d,'%s',%d,%d);",
+              atoi(tok_id), name, atoi(qty), atoi(min));
+    } else if (strcmp(table, "transactions") == 0) {
+      char *tok_id = next_token(&ptr);
+      char *stock_id = next_token(&ptr);
+      char *qty = next_token(&ptr);
+      char *type = next_token(&ptr);
+      char *timestamp = ptr;
+      db_exec(
+          "INSERT INTO transactions(id,stock_id,quantity,type,timestamp) VALUES(%d,%d,%d,'%s',%d);",
+          atoi(tok_id), atoi(stock_id), atoi(qty), type, atoi(timestamp));
+    }
+  }
+
+  sqlite3_exec(db_handle, "COMMIT;", NULL, NULL, NULL);
+  fclose(f);
+  ESP_LOGI(TAG, "Import CSV depuis %s termine", path);
+}

--- a/components/db/db.h
+++ b/components/db/db.h
@@ -29,6 +29,13 @@ void db_export_csv(const char *path);
 void db_export_json(const char *path);
 
 /**
+ * \brief Importe les donnees depuis un fichier CSV exporte.
+ *        Le fichier doit suivre le format produit par db_export_csv().
+ * \param path Chemin du fichier CSV en clair.
+ */
+void db_import_csv(const char *path);
+
+/**
  * \brief Execute une requete SQL sans retour de resultats.
  */
 bool db_exec(const char *format, ...);

--- a/components/storage/storage.c
+++ b/components/storage/storage.c
@@ -257,3 +257,14 @@ void storage_restore(void)
         ESP_LOGE(TAG, "Echec restauration");
     }
 }
+
+void storage_import_csv(const char *path)
+{
+    ESP_LOGI(TAG, "Import CSV depuis %s", path);
+    if (!storage_decrypt_file(path, "/sdcard/import_tmp.csv")) {
+        ESP_LOGE(TAG, "Echec dechiffrement");
+        return;
+    }
+    db_import_csv("/sdcard/import_tmp.csv");
+    remove("/sdcard/import_tmp.csv");
+}

--- a/components/storage/storage.h
+++ b/components/storage/storage.h
@@ -41,6 +41,12 @@ bool storage_wifi_transfer(const char *path, const char *url);
 void storage_restore(void);
 
 /**
+ * \brief Importe un fichier CSV exporte dans la base.
+ * \param path Fichier chiffre a importer.
+ */
+void storage_import_csv(const char *path);
+
+/**
  * \brief Chiffre un fichier de stockage local.
  * \param path Chemin du fichier à chiffrer.
  */

--- a/components/ui/ui.c
+++ b/components/ui/ui.c
@@ -29,6 +29,7 @@ static const char *translations[UI_LANG_COUNT][TXT_COUNT] = {
         [TXT_SETTINGS] = "Settings",
         [TXT_EXPORT] = "Export",
         [TXT_IMPORT] = "Import",
+        [TXT_IMPORT_CSV] = "Import CSV",
         [TXT_LEGAL_OK] = "OK",
         [TXT_LEGAL_EXPIRED] = "Expired",
         [TXT_LANGUAGE] = "Language",
@@ -69,6 +70,7 @@ static const char *translations[UI_LANG_COUNT][TXT_COUNT] = {
         [TXT_SETTINGS] = "Param\xC3\xA8tres",
         [TXT_EXPORT] = "Exporter",
         [TXT_IMPORT] = "Importer",
+        [TXT_IMPORT_CSV] = "Importer CSV",
         [TXT_LEGAL_OK] = "OK",
         [TXT_LEGAL_EXPIRED] = "Expire",
         [TXT_LANGUAGE] = "Langue",
@@ -1259,6 +1261,12 @@ static void import_event(lv_event_t *e)
     ui_notify("Import OK");
 }
 
+static void import_csv_event(lv_event_t *e)
+{
+    storage_import_csv("/sdcard/export.csv");
+    ui_notify("Import CSV OK");
+}
+
 static void lang_event(lv_event_t *e)
 {
     uint32_t sel = lv_dropdown_get_selected(lv_event_get_target(e));
@@ -1293,6 +1301,11 @@ static void settings_tab_create(lv_obj_t *tab)
     lv_obj_add_event_cb(btn_import, import_event, LV_EVENT_CLICKED, NULL);
     lv_obj_t *lbl2 = lv_label_create(btn_import);
     lv_label_set_text(lbl2, ui_get_text(TXT_IMPORT));
+
+    lv_obj_t *btn_import_csv = lv_btn_create(tab);
+    lv_obj_align(btn_import_csv, LV_ALIGN_BOTTOM_MID, 0, -10);
+    lv_obj_add_event_cb(btn_import_csv, import_csv_event, LV_EVENT_CLICKED, NULL);
+    lv_label_set_text(lv_label_create(btn_import_csv), ui_get_text(TXT_IMPORT_CSV));
 }
 
 const char *ui_get_text(ui_text_id_t id)

--- a/components/ui/ui.h
+++ b/components/ui/ui.h
@@ -63,6 +63,7 @@ typedef enum {
     TXT_QUANTITY,
     TXT_MIN,
     TXT_STOCK_ID,
+    TXT_IMPORT_CSV,
     TXT_COUNT
 } ui_text_id_t;
 

--- a/docs/CONFIG_EXAMPLE.md
+++ b/docs/CONFIG_EXAMPLE.md
@@ -22,3 +22,7 @@ Ce fichier illustre comment définir certaines options via `sdkconfig`.
 `CONFIG_STORAGE_TRANSFER_URL` indique l'endpoint HTTP pour l'envoi de fichiers.
 Si le serveur requiert une authentification basique, renseignez
 `CONFIG_STORAGE_TRANSFER_USERNAME` et `CONFIG_STORAGE_TRANSFER_PASSWORD`.
+
+Pour r\xC3\xA9importer une sauvegarde CSV, copiez le fichier chiffr\xC3\xA9 sur la
+carte SD puis utilisez le bouton **Import CSV** dans l'interface. La base sera
+alors vid\xC3\xA9e et remplie avec les donn\xC3\xA9es du fichier.

--- a/tests/test_ui.c
+++ b/tests/test_ui.c
@@ -42,6 +42,7 @@ typedef enum {
     TXT_QUANTITY,
     TXT_MIN,
     TXT_STOCK_ID,
+    TXT_IMPORT_CSV,
     TXT_COUNT
 } ui_text_id_t;
 
@@ -58,6 +59,7 @@ static const char *translations[UI_LANG_COUNT][TXT_COUNT] = {
         [TXT_SETTINGS] = "Settings",
         [TXT_EXPORT] = "Export",
         [TXT_IMPORT] = "Import",
+        [TXT_IMPORT_CSV] = "Import CSV",
         [TXT_LEGAL_OK] = "OK",
         [TXT_LEGAL_EXPIRED] = "Expired",
         [TXT_LANGUAGE] = "Language",
@@ -98,6 +100,7 @@ static const char *translations[UI_LANG_COUNT][TXT_COUNT] = {
         [TXT_SETTINGS] = "Param\xC3\xA8tres",
         [TXT_EXPORT] = "Exporter",
         [TXT_IMPORT] = "Importer",
+        [TXT_IMPORT_CSV] = "Importer CSV",
         [TXT_LEGAL_OK] = "OK",
         [TXT_LEGAL_EXPIRED] = "Expire",
         [TXT_LANGUAGE] = "Langue",


### PR DESCRIPTION
## Summary
- implement `db_import_csv` to restore database tables from CSV
- wrap CSV import with `storage_import_csv`
- add Import CSV button in settings UI
- document new functionality in `CONFIG_EXAMPLE.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68602d3a8f348323a66fe7dab9051d89