### PR TITLE
Update legal component source list

### DIFF
--- a/components/legal/CMakeLists.txt
+++ b/components/legal/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(
-    SRCS "legal_numbers.c"
+    SRCS "legal.c" "legal_templates.c"
     INCLUDE_DIRS "."
 )


### PR DESCRIPTION
## Summary
- fix CMakeLists for the `legal` component so it uses the correct sources
- keep `legal_numbers.c` only in its own component

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605839d4e08323a5f667811597a65c