### PR TITLE
Add DB default key Kconfig

### DIFF
--- a/components/db/CMakeLists.txt
+++ b/components/db/CMakeLists.txt
@@ -1,2 +1,6 @@
 idf_component_register(SRCS "db.c"
                        INCLUDE_DIRS ".")
+
+# Expose project configuration options
+set_property(TARGET ${COMPONENT_LIB} PROPERTY
+             KCONFIG_PROJBUILD ${CMAKE_CURRENT_LIST_DIR}/Kconfig.projbuild)

--- a/components/db/Kconfig.projbuild
+++ b/components/db/Kconfig.projbuild
@@ -1,0 +1,6 @@
+config DB_DEFAULT_KEY
+    string "Default SQLCipher key"
+    default ""
+    help
+        Default encryption key used for lizard.db when SQLCipher is available.
+        Leave empty to input the key manually on first boot.

--- a/docs/CONFIG_EXAMPLE.md
+++ b/docs/CONFIG_EXAMPLE.md
@@ -23,6 +23,10 @@ Ce fichier illustre comment définir certaines options via `sdkconfig`.
 Si le serveur requiert une authentification basique, renseignez
 `CONFIG_STORAGE_TRANSFER_USERNAME` et `CONFIG_STORAGE_TRANSFER_PASSWORD`.
 
+`CONFIG_DB_DEFAULT_KEY` permet de définir la clé SQLCipher utilisée lors du
+premier démarrage. Laisser ce champ vide obligera l'utilisateur à saisir la
+clé manuellement.
+
 Pour r\xC3\xA9importer une sauvegarde CSV, copiez le fichier chiffr\xC3\xA9 sur la
 carte SD puis utilisez le bouton **Import CSV** dans l'interface. La base sera
 alors vid\xC3\xA9e et remplie avec les donn\xC3\xA9es du fichier.


### PR DESCRIPTION
## Summary
- introduce `Kconfig.projbuild` for the DB component
- reference Kconfig in component CMake
- explain the option in `CONFIG_EXAMPLE.md`

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68605997ae348323b3ce4059c40384c0