### PR TITLE
Add UI translation tests

### DIFF
--- a/tests/test_ui.c
+++ b/tests/test_ui.c
@@ -159,9 +159,13 @@ TEST_CASE("ui language switching","[ui]")
 {
     ui_init(UI_LANG_EN, UI_THEME_LIGHT);
     TEST_ASSERT_EQUAL_STRING("Animals", ui_get_text(TXT_ANIMALS));
+    TEST_ASSERT_EQUAL_STRING("Import CSV", ui_get_text(TXT_IMPORT_CSV));
+    TEST_ASSERT_EQUAL_STRING("Stock ID", ui_get_text(TXT_STOCK_ID));
     ui_set_language(UI_LANG_FR);
     TEST_ASSERT_EQUAL_STRING("Animaux", ui_get_text(TXT_ANIMALS));
     TEST_ASSERT_EQUAL_STRING("Fermer", ui_get_text(TXT_CLOSE));
+    TEST_ASSERT_EQUAL_STRING("Importer CSV", ui_get_text(TXT_IMPORT_CSV));
+    TEST_ASSERT_EQUAL_STRING("ID Stock", ui_get_text(TXT_STOCK_ID));
 }
 
 TEST_CASE("ui theme switching","[ui]")


### PR DESCRIPTION
## Summary
- add checks for new translations like `TXT_IMPORT_CSV` and `TXT_STOCK_ID` in UI tests

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605be3073c8323a941801b9f5387f6