### PR TITLE
Add SQLite component via ESP-IDF component manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ LizardComette est un exemple de projet ESP‑IDF permettant de gérer un élevag
 idf.py set-target esp32s3
 idf.py build
 ```
+Le composant `espressif/sqlite` déclaré dans `idf_component.yml` sera alors
+téléchargé automatiquement via le component manager. Vous pouvez aussi
+l'ajouter explicitement avec `idf.py add-dependency`.
 
 ## Utilisation
 Une fois flashé sur votre ESP32, le firmware démarre l'interface graphique en français ou en anglais selon la configuration. Les modules s'initialisent automatiquement puis le planificateur vérifie les tâches à venir. Consultez `docs/UI_USAGE.md` pour le détail des écrans et `docs/NOTICE.md` pour les avertissements légaux.

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,3 @@
+version: "1.0.0"
+dependencies:
+  espressif/sqlite: "*"


### PR DESCRIPTION
## Summary
- declare `espressif/sqlite` dependency
- document automatic download through the component manager

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860609996e083238356c93045efe6d8