### PR TITLE
Add missing dependencies for legal component

### DIFF
--- a/components/legal/CMakeLists.txt
+++ b/components/legal/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
     SRCS "legal.c" "legal_templates.c"
     INCLUDE_DIRS "."
+    REQUIRES animals db ui
 )


### PR DESCRIPTION
## Summary
- expose animals, db and ui headers in `legal` component via `REQUIRES`

## Testing
- `idf.py build && idf.py unity_test` *(fails: `idf.py` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606126e18c832386122d0e287ee4e0