### PR TITLE
Add missing db dependencies

### DIFF
--- a/components/animals/CMakeLists.txt
+++ b/components/animals/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "animals.c" "health.c" "breeding.c"
-                       INCLUDE_DIRS ".")
+                       INCLUDE_DIRS "."
+                       REQUIRES db)

--- a/components/stocks/CMakeLists.txt
+++ b/components/stocks/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "stocks.c"
-                       INCLUDE_DIRS ".")
+                       INCLUDE_DIRS "."
+                       REQUIRES db)

--- a/components/transactions/CMakeLists.txt
+++ b/components/transactions/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "transactions.c"
-                       INCLUDE_DIRS ".")
+                       INCLUDE_DIRS "."
+                       REQUIRES db)


### PR DESCRIPTION
## Summary
- link animals, stocks and transactions components to `db`

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686061d9bd208323b7933e3f123365df