### PR TITLE
Add sqlite3 requirement to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ LizardComette est un exemple de projet ESP‑IDF permettant de gérer un élevag
 idf.py set-target esp32s3
 idf.py build
 ```
-Le composant `espressif/sqlite` déclaré dans `idf_component.yml` sera alors
-téléchargé automatiquement via le component manager. Vous pouvez aussi
-l'ajouter explicitement avec `idf.py add-dependency`.
+Le projet a besoin du composant `sqlite3` fourni par l'ESP‑IDF. Celui‑ci est
+déclaré dans `idf_component.yml` sous le nom `espressif/sqlite` et sera
+téléchargé automatiquement. Vous pouvez aussi l'ajouter manuellement avec
+`idf.py add-dependency` ou en le plaçant dans le répertoire `components/`.
 
 ## Utilisation
 Une fois flashé sur votre ESP32, le firmware démarre l'interface graphique en français ou en anglais selon la configuration. Les modules s'initialisent automatiquement puis le planificateur vérifie les tâches à venir. Consultez `docs/UI_USAGE.md` pour le détail des écrans et `docs/NOTICE.md` pour les avertissements légaux.

--- a/components/animals/CMakeLists.txt
+++ b/components/animals/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "animals.c" "health.c" "breeding.c"
                        INCLUDE_DIRS "."
-                       REQUIRES db)
+                       REQUIRES db sqlite3)

--- a/components/auth/CMakeLists.txt
+++ b/components/auth/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "auth.c"
                        INCLUDE_DIRS "."
-                       REQUIRES mbedtls)
+                       REQUIRES mbedtls db sqlite3)

--- a/components/db/CMakeLists.txt
+++ b/components/db/CMakeLists.txt
@@ -1,5 +1,6 @@
 idf_component_register(SRCS "db.c"
-                       INCLUDE_DIRS ".")
+                       INCLUDE_DIRS "."
+                       REQUIRES sqlite3)
 
 # Expose project configuration options
 set_property(TARGET ${COMPONENT_LIB} PROPERTY

--- a/components/elevages/CMakeLists.txt
+++ b/components/elevages/CMakeLists.txt
@@ -1,2 +1,3 @@
-idf_component_register(SRCS "elevages.c" 
-                       INCLUDE_DIRS ".")
+idf_component_register(SRCS "elevages.c"
+                       INCLUDE_DIRS "."
+                       REQUIRES db sqlite3)

--- a/components/legal_numbers/CMakeLists.txt
+++ b/components/legal_numbers/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
-	SRCS "legal_numbers.c" 
+        SRCS "legal_numbers.c"
         INCLUDE_DIRS "."
+        REQUIRES db sqlite3
 )

--- a/components/stocks/CMakeLists.txt
+++ b/components/stocks/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "stocks.c"
                        INCLUDE_DIRS "."
-                       REQUIRES db)
+                       REQUIRES db sqlite3)

--- a/components/terrariums/CMakeLists.txt
+++ b/components/terrariums/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "terrariums.c"
-                       INCLUDE_DIRS ".")
+                       INCLUDE_DIRS "."
+                       REQUIRES db sqlite3)

--- a/components/transactions/CMakeLists.txt
+++ b/components/transactions/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "transactions.c"
                        INCLUDE_DIRS "."
-                       REQUIRES db)
+                       REQUIRES db sqlite3)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "test_auth.c" "test_db.c" "test_legal.c" "test_crud.c" \
                        "test_scheduler.c" "test_ui.c"
                        INCLUDE_DIRS ".."
-                      REQUIRES db auth legal legal_numbers animals terrariums stocks transactions scheduler unity)
+                      REQUIRES db sqlite3 auth legal legal_numbers animals terrariums stocks transactions scheduler unity)


### PR DESCRIPTION
## Summary
- require sqlite3 in the db component and all modules using SQLite
- mention sqlite3 dependency when building

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606555377483239a5e1068f7ceb88f