### PR TITLE
Add Wi-Fi transfer configuration options

### DIFF
--- a/components/storage/CMakeLists.txt
+++ b/components/storage/CMakeLists.txt
@@ -1,3 +1,7 @@
 idf_component_register(SRCS "storage.c"
                        INCLUDE_DIRS "."
                        REQUIRES mbedtls db legal esp_http_client fatfs sdmmc)
+
+# Expose project configuration options
+set_property(TARGET ${COMPONENT_LIB} PROPERTY
+             KCONFIG_PROJBUILD ${CMAKE_CURRENT_LIST_DIR}/Kconfig.projbuild)

--- a/components/storage/Kconfig.projbuild
+++ b/components/storage/Kconfig.projbuild
@@ -1,0 +1,17 @@
+config STORAGE_TRANSFER_URL
+    string "HTTP endpoint for file uploads"
+    default ""
+    help
+        Base URL used when transferring files via Wi-Fi.
+
+config STORAGE_TRANSFER_USERNAME
+    string "HTTP authentication username"
+    default ""
+    help
+        Optional username if the server requires authentication.
+
+config STORAGE_TRANSFER_PASSWORD
+    string "HTTP authentication password"
+    default ""
+    help
+        Optional password if the server requires authentication.

--- a/docs/CONFIG_EXAMPLE.md
+++ b/docs/CONFIG_EXAMPLE.md
@@ -24,6 +24,8 @@ L'authentification HTTP est facultative. Si elle est nécessaire,
 renseignez `CONFIG_STORAGE_TRANSFER_USERNAME` et
 `CONFIG_STORAGE_TRANSFER_PASSWORD` ; sinon, ces variables peuvent être
 laissées vides ou omises.
+Ces trois options sont définies dans `components/storage/Kconfig.projbuild` et
+contrôlent le transfert de fichiers via le Wi‑Fi.
 
 `CONFIG_DB_DEFAULT_KEY` permet de définir la clé SQLCipher utilisée lors du
 premier démarrage. Laisser ce champ vide obligera l'utilisateur à saisir la


### PR DESCRIPTION
## Summary
- add Kconfig options for transfer URL, username and password
- expose storage Kconfig in CMakeLists
- document storage transfer options in config example

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606976bd68832389338da22a348f66