### PR TITLE
Add drivers config options

### DIFF
--- a/components/drivers/Kconfig.projbuild
+++ b/components/drivers/Kconfig.projbuild
@@ -1,0 +1,60 @@
+config DRIVERS_REST_URL
+    string "REST endpoint for sensor data"
+    default ""
+    help
+        Base URL for HTTP posts performed by the drivers component.
+
+config DRIVERS_MQTT_URI
+    string "MQTT broker URI for sensors"
+    default ""
+    help
+        URI used when connecting to the MQTT broker to publish sensor data.
+
+config DRIVERS_MQTT_TOPIC
+    string "MQTT topic for sensor data"
+    default ""
+    help
+        Topic used when publishing sensor measurements.
+
+config LIGHTING_PWM_GPIO
+    int "GPIO for lighting PWM"
+    default 5
+    help
+        Pin connected to the lighting PWM output.
+
+config LIGHTING_REST_URL
+    string "REST endpoint for lighting state"
+    default ""
+    help
+        URL used when sending lighting state over HTTP.
+
+config LIGHTING_MQTT_TOPIC
+    string "MQTT topic for lighting state"
+    default ""
+    help
+        Topic used when publishing lighting state via MQTT.
+
+config CO2_SDA_GPIO
+    int "GPIO for CO2 sensor SDA"
+    default 21
+
+config CO2_SCL_GPIO
+    int "GPIO for CO2 sensor SCL"
+    default 22
+
+config CO2_I2C_ADDR
+    hex "I2C address of CO2 sensor"
+    default 0x61
+
+config CO2_REST_URL
+    string "REST endpoint for CO2 measurements"
+    default ""
+    help
+        URL used when posting CO2 data over HTTP.
+
+config CO2_MQTT_TOPIC
+    string "MQTT topic for CO2 measurements"
+    default ""
+    help
+        Topic used when publishing CO2 data via MQTT.
+

--- a/components/drivers/co2.c
+++ b/components/drivers/co2.c
@@ -6,15 +6,6 @@
 
 static const char *TAG = "co2";
 
-#ifndef CONFIG_CO2_SDA_GPIO
-#define CONFIG_CO2_SDA_GPIO 21
-#endif
-#ifndef CONFIG_CO2_SCL_GPIO
-#define CONFIG_CO2_SCL_GPIO 22
-#endif
-#ifndef CONFIG_CO2_I2C_ADDR
-#define CONFIG_CO2_I2C_ADDR 0x61
-#endif
 #define I2C_PORT I2C_NUM_0
 #define I2C_FREQ_HZ 100000
 

--- a/components/drivers/lighting.c
+++ b/components/drivers/lighting.c
@@ -6,9 +6,6 @@
 
 static const char *TAG = "lighting";
 
-#ifndef CONFIG_LIGHTING_PWM_GPIO
-#define CONFIG_LIGHTING_PWM_GPIO 5
-#endif
 
 #define LEDC_TIMER   LEDC_TIMER_0
 #define LEDC_CHANNEL LEDC_CHANNEL_0

--- a/docs/CONFIG_EXAMPLE.md
+++ b/docs/CONFIG_EXAMPLE.md
@@ -16,6 +16,9 @@ CONFIG_LIGHTING_REST_URL="http://example.com/light"
 CONFIG_LIGHTING_MQTT_TOPIC="/lizard/light"
 CONFIG_CO2_REST_URL="http://example.com/co2"
 CONFIG_CO2_MQTT_TOPIC="/lizard/co2"
+CONFIG_CO2_SDA_GPIO=21
+CONFIG_CO2_SCL_GPIO=22
+CONFIG_CO2_I2C_ADDR=0x61
 ```
 
 Ce fichier illustre comment définir certaines options via `sdkconfig`.
@@ -26,6 +29,10 @@ renseignez `CONFIG_STORAGE_TRANSFER_USERNAME` et
 laissées vides ou omises.
 Ces trois options sont définies dans `components/storage/Kconfig.projbuild` et
 contrôlent le transfert de fichiers via le Wi‑Fi.
+
+`CONFIG_LIGHTING_PWM_GPIO` indique le GPIO utilisé pour piloter l'éclairage.
+Les options `CONFIG_CO2_SDA_GPIO`, `CONFIG_CO2_SCL_GPIO` et
+`CONFIG_CO2_I2C_ADDR` permettent d'adapter le câblage du capteur CO2.
 
 `CONFIG_DB_DEFAULT_KEY` permet de définir la clé SQLCipher utilisée lors du
 premier démarrage. Laisser ce champ vide obligera l'utilisateur à saisir la


### PR DESCRIPTION
## Summary
- add `components/drivers/Kconfig.projbuild`
- rely on Kconfig in lighting and CO2 drivers
- document new CO2 options

## Testing
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68606a31f6b883239dcbf9dd841a5380