### PR TITLE
Update CI to reconfigure before build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,15 @@ jobs:
       - uses: espressif/github-actions/setup-esp-idf@v1
         with:
           version: latest
+      - name: Cache managed components
+        uses: actions/cache@v3
+        with:
+          path: managed_components
+          key: ${{ runner.os }}-managed-components-${{ hashFiles('idf_component.yml') }}
+          restore-keys: ${{ runner.os }}-managed-components-
       - name: Build
-        run: idf.py build
+        run: |
+          idf.py reconfigure
+          idf.py build
       - name: Run unit tests
         run: idf.py build && idf.py unity_test


### PR DESCRIPTION
## Summary
- run `idf.py reconfigure` before `idf.py build`
- cache `managed_components` to speed up CI

## Testing
- `idf.py reconfigure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606bd4a4848323a421c4e3e9a6b630