### PR TITLE
Use bound parameters for SQL CRUD operations

### DIFF
--- a/components/animals/animals.c
+++ b/components/animals/animals.c
@@ -55,16 +55,32 @@ void animals_init(void) {
 bool animals_add(const Reptile *r) {
   if (animal_count >= ANIMALS_MAX || !r)
     return false;
-  if (!db_exec("INSERT INTO "
+  sqlite3_stmt *stmt =
+      db_query("INSERT INTO "
                "animals(id,elevage_id,name,species,sex,birth_date,health,"
                "breeding_cycle,cdc_number,aoe_number,ifap_id,quota_limit,quota_"
                "used,cerfa_valid_until,cites_valid_until) "
-               "VALUES(%d,%d,'%s','%s','%s','%s','%s','%s','%s','%s','%s',%d,%"
-               "d,%d,%d);",
-               r->id, r->elevage_id, r->name, r->species, r->sex, r->birth_date,
-               r->health, r->breeding_cycle, r->cdc_number, r->aoe_number,
-               r->ifap_id, r->quota_limit, r->quota_used, r->cerfa_valid_until,
-               r->cites_valid_until))
+               "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);");
+  if (!stmt)
+    return false;
+  sqlite3_bind_int(stmt, 1, r->id);
+  sqlite3_bind_int(stmt, 2, r->elevage_id);
+  sqlite3_bind_text(stmt, 3, r->name, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 4, r->species, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 5, r->sex, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 6, r->birth_date, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 7, r->health, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 8, r->breeding_cycle, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 9, r->cdc_number, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 10, r->aoe_number, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 11, r->ifap_id, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_int(stmt, 12, r->quota_limit);
+  sqlite3_bind_int(stmt, 13, r->quota_used);
+  sqlite3_bind_int(stmt, 14, r->cerfa_valid_until);
+  sqlite3_bind_int(stmt, 15, r->cites_valid_until);
+  bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+  sqlite3_finalize(stmt);
+  if (!ok)
     return false;
   animals[animal_count] = *r;
   animal_count++;
@@ -91,15 +107,31 @@ bool animals_update(int id, const Reptile *r) {
   int idx = find_index(id);
   if (idx < 0 || !r)
     return false;
-  if (!db_exec(
-          "UPDATE animals SET elevage_id=%d,name='%s',species='%s',sex='%s',"
-          "birth_date='%s',health='%s',breeding_cycle='%s',cdc_number='%s',aoe_"
-          "number='%s',ifap_id='%s',quota_limit=%d,quota_used=%d,cerfa_valid_"
-          "until=%d,cites_valid_until=%d WHERE id=%d;",
-          r->elevage_id, r->name, r->species, r->sex, r->birth_date, r->health,
-          r->breeding_cycle, r->cdc_number, r->aoe_number, r->ifap_id,
-          r->quota_limit, r->quota_used, r->cerfa_valid_until,
-          r->cites_valid_until, id))
+  sqlite3_stmt *stmt =
+      db_query("UPDATE animals SET elevage_id=?,name=?,species=?,sex=?,"
+               "birth_date=?,health=?,breeding_cycle=?,cdc_number=?,aoe_number=?,"
+               "ifap_id=?,quota_limit=?,quota_used=?,cerfa_valid_until=?,cites_"
+               "valid_until=? WHERE id=?;");
+  if (!stmt)
+    return false;
+  sqlite3_bind_int(stmt, 1, r->elevage_id);
+  sqlite3_bind_text(stmt, 2, r->name, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 3, r->species, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 4, r->sex, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 5, r->birth_date, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 6, r->health, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 7, r->breeding_cycle, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 8, r->cdc_number, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 9, r->aoe_number, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 10, r->ifap_id, -1, SQLITE_TRANSIENT);
+  sqlite3_bind_int(stmt, 11, r->quota_limit);
+  sqlite3_bind_int(stmt, 12, r->quota_used);
+  sqlite3_bind_int(stmt, 13, r->cerfa_valid_until);
+  sqlite3_bind_int(stmt, 14, r->cites_valid_until);
+  sqlite3_bind_int(stmt, 15, id);
+  bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+  sqlite3_finalize(stmt);
+  if (!ok)
     return false;
   animals[idx] = *r;
   ESP_LOGI(TAG, "Mise a jour du reptile %d", id);
@@ -110,7 +142,14 @@ bool animals_delete(int id) {
   int idx = find_index(id);
   if (idx < 0)
     return false;
-  if (!db_exec("DELETE FROM animals WHERE id=%d;", id))
+  sqlite3_stmt *stmt =
+      db_query("DELETE FROM animals WHERE id=?;");
+  if (!stmt)
+    return false;
+  sqlite3_bind_int(stmt, 1, id);
+  bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+  sqlite3_finalize(stmt);
+  if (!ok)
     return false;
   for (int i = idx; i < animal_count - 1; ++i) {
     animals[i] = animals[i + 1];

--- a/components/animals/breeding.c
+++ b/components/animals/breeding.c
@@ -41,8 +41,17 @@ bool breeding_add(const BreedingEvent *ev)
 {
     if (event_count >= BREEDING_MAX || !ev)
         return false;
-    if (!db_exec("INSERT INTO breeding_events(id,animal_id,description,date) VALUES(%d,%d,'%s',%d);",
-                 ev->id, ev->animal_id, ev->description, ev->date))
+    sqlite3_stmt *stmt = db_query(
+        "INSERT INTO breeding_events(id,animal_id,description,date) VALUES(?,?,?,?);");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, ev->id);
+    sqlite3_bind_int(stmt, 2, ev->animal_id);
+    sqlite3_bind_text(stmt, 3, ev->description, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 4, ev->date);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     events[event_count] = *ev;
     event_count++;
@@ -63,8 +72,17 @@ bool breeding_update(int id, const BreedingEvent *ev)
     int idx = find_index(id);
     if (idx < 0 || !ev)
         return false;
-    if (!db_exec("UPDATE breeding_events SET animal_id=%d,description='%s',date=%d WHERE id=%d;",
-                 ev->animal_id, ev->description, ev->date, id))
+    sqlite3_stmt *stmt = db_query(
+        "UPDATE breeding_events SET animal_id=?,description=?,date=? WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, ev->animal_id);
+    sqlite3_bind_text(stmt, 2, ev->description, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 3, ev->date);
+    sqlite3_bind_int(stmt, 4, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     events[idx] = *ev;
     events[idx].id = id;
@@ -77,7 +95,13 @@ bool breeding_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    if (!db_exec("DELETE FROM breeding_events WHERE id=%d;", id))
+    sqlite3_stmt *stmt = db_query("DELETE FROM breeding_events WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     for (int i = idx; i < event_count - 1; ++i)
         events[i] = events[i + 1];

--- a/components/animals/health.c
+++ b/components/animals/health.c
@@ -41,8 +41,17 @@ bool health_add(const HealthRecord *rec)
 {
     if (record_count >= HEALTH_MAX || !rec)
         return false;
-    if (!db_exec("INSERT INTO health_records(id,animal_id,description,date) VALUES(%d,%d,'%s',%d);",
-                 rec->id, rec->animal_id, rec->description, rec->date))
+    sqlite3_stmt *stmt = db_query(
+        "INSERT INTO health_records(id,animal_id,description,date) VALUES(?,?,?,?);");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, rec->id);
+    sqlite3_bind_int(stmt, 2, rec->animal_id);
+    sqlite3_bind_text(stmt, 3, rec->description, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 4, rec->date);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     records[record_count] = *rec;
     record_count++;
@@ -63,8 +72,17 @@ bool health_update(int id, const HealthRecord *rec)
     int idx = find_index(id);
     if (idx < 0 || !rec)
         return false;
-    if (!db_exec("UPDATE health_records SET animal_id=%d,description='%s',date=%d WHERE id=%d;",
-                 rec->animal_id, rec->description, rec->date, id))
+    sqlite3_stmt *stmt = db_query(
+        "UPDATE health_records SET animal_id=?,description=?,date=? WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, rec->animal_id);
+    sqlite3_bind_text(stmt, 2, rec->description, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 3, rec->date);
+    sqlite3_bind_int(stmt, 4, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     records[idx] = *rec;
     records[idx].id = id;
@@ -77,7 +95,13 @@ bool health_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    if (!db_exec("DELETE FROM health_records WHERE id=%d;", id))
+    sqlite3_stmt *stmt = db_query("DELETE FROM health_records WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     for (int i = idx; i < record_count - 1; ++i)
         records[i] = records[i + 1];

--- a/components/auth/auth.c
+++ b/components/auth/auth.c
@@ -111,8 +111,16 @@ bool auth_add_user(const char *username, const char *password, user_role_t role)
 
     char hex[65];
     hash_to_hex(users[user_count].hash, hex);
-    if (!db_exec("INSERT INTO users(username,hash,role) VALUES('%s','%s',%d);",
-                 users[user_count].username, hex, role))
+    sqlite3_stmt *stmt =
+        db_query("INSERT INTO users(username,hash,role) VALUES(?,?,?);");
+    if (!stmt)
+        return false;
+    sqlite3_bind_text(stmt, 1, users[user_count].username, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 2, hex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 3, role);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
 
     user_count++;
@@ -146,8 +154,15 @@ bool auth_link_elevage(const char *username, int elevage_id)
         if (strcmp(users[i].username, username) == 0) {
             if (users[i].elevage_count >= AUTH_MAX_ELEVAGES_PER_USER)
                 return false;
-            if (!db_exec("INSERT INTO user_elevages(username,elevage_id) VALUES('%s',%d);",
-                         username, elevage_id))
+            sqlite3_stmt *stmt =
+                db_query("INSERT INTO user_elevages(username,elevage_id) VALUES(?,?);");
+            if (!stmt)
+                return false;
+            sqlite3_bind_text(stmt, 1, username, -1, SQLITE_TRANSIENT);
+            sqlite3_bind_int(stmt, 2, elevage_id);
+            bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+            sqlite3_finalize(stmt);
+            if (!ok)
                 return false;
             users[i].elevages[users[i].elevage_count++] = elevage_id;
             return true;

--- a/components/elevages/elevages.c
+++ b/components/elevages/elevages.c
@@ -41,8 +41,16 @@ bool elevages_add(const Elevage *e)
 {
     if (elevage_count >= ELEVAGES_MAX || !e)
         return false;
-    if (!db_exec("INSERT INTO elevages(id,name,description) VALUES(%d,'%s','%s');",
-                 e->id, e->name, e->description))
+    sqlite3_stmt *stmt =
+        db_query("INSERT INTO elevages(id,name,description) VALUES(?,?,?);");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, e->id);
+    sqlite3_bind_text(stmt, 2, e->name, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 3, e->description, -1, SQLITE_TRANSIENT);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     elevages[elevage_count] = *e;
     elevage_count++;
@@ -63,8 +71,16 @@ bool elevages_update(int id, const Elevage *e)
     int idx = find_index(id);
     if (idx < 0 || !e)
         return false;
-    if (!db_exec("UPDATE elevages SET name='%s',description='%s' WHERE id=%d;",
-                 e->name, e->description, id))
+    sqlite3_stmt *stmt =
+        db_query("UPDATE elevages SET name=?,description=? WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_text(stmt, 1, e->name, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 2, e->description, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 3, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     elevages[idx] = *e;
     ESP_LOGI(TAG, "Mise a jour de l'elevage %d", id);
@@ -76,7 +92,13 @@ bool elevages_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    if (!db_exec("DELETE FROM elevages WHERE id=%d;", id))
+    sqlite3_stmt *stmt = db_query("DELETE FROM elevages WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     for (int i = idx; i < elevage_count - 1; ++i) {
         elevages[i] = elevages[i + 1];

--- a/components/legal_numbers/legal_numbers.c
+++ b/components/legal_numbers/legal_numbers.c
@@ -49,8 +49,18 @@ bool legal_numbers_add(const LegalNumber *n)
 {
     if (number_count >= LEGAL_NUMBERS_MAX || !n)
         return false;
-    if (!db_exec("INSERT INTO cdc_aoe_numbers(id,username,elevage_id,type,number) VALUES(%d,'%s',%d,'%s','%s');",
-                 n->id, n->username, n->elevage_id, n->type, n->number))
+    sqlite3_stmt *stmt = db_query(
+        "INSERT INTO cdc_aoe_numbers(id,username,elevage_id,type,number) VALUES(?,?,?,?,?);");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, n->id);
+    sqlite3_bind_text(stmt, 2, n->username, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 3, n->elevage_id);
+    sqlite3_bind_text(stmt, 4, n->type, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 5, n->number, -1, SQLITE_TRANSIENT);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     numbers[number_count] = *n;
     number_count++;
@@ -71,8 +81,18 @@ bool legal_numbers_update(int id, const LegalNumber *n)
     int idx = find_index(id);
     if (idx < 0 || !n)
         return false;
-    if (!db_exec("UPDATE cdc_aoe_numbers SET username='%s',elevage_id=%d,type='%s',number='%s' WHERE id=%d;",
-                 n->username, n->elevage_id, n->type, n->number, id))
+    sqlite3_stmt *stmt =
+        db_query("UPDATE cdc_aoe_numbers SET username=?,elevage_id=?,type=?,number=? WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_text(stmt, 1, n->username, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 2, n->elevage_id);
+    sqlite3_bind_text(stmt, 3, n->type, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 4, n->number, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 5, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     numbers[idx] = *n;
     ESP_LOGI(TAG, "Mise a jour numero %d", id);
@@ -84,7 +104,13 @@ bool legal_numbers_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    if (!db_exec("DELETE FROM cdc_aoe_numbers WHERE id=%d;", id))
+    sqlite3_stmt *stmt = db_query("DELETE FROM cdc_aoe_numbers WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     for (int i = idx; i < number_count - 1; ++i)
         numbers[i] = numbers[i + 1];

--- a/components/stocks/stocks.c
+++ b/components/stocks/stocks.c
@@ -42,8 +42,17 @@ bool stocks_add(const StockItem *item)
 {
     if (stock_count >= STOCKS_MAX || !item)
         return false;
-    if (!db_exec("INSERT INTO stocks(id,name,quantity,min_quantity) VALUES(%d,'%s',%d,%d);",
-                 item->id, item->name, item->quantity, item->min_quantity))
+    sqlite3_stmt *stmt =
+        db_query("INSERT INTO stocks(id,name,quantity,min_quantity) VALUES(?,?,?,?);");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, item->id);
+    sqlite3_bind_text(stmt, 2, item->name, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 3, item->quantity);
+    sqlite3_bind_int(stmt, 4, item->min_quantity);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     stock_items[stock_count] = *item;
     stock_count++;
@@ -64,8 +73,17 @@ bool stocks_update(int id, const StockItem *item)
     int idx = find_index(id);
     if (idx < 0 || !item)
         return false;
-    if (!db_exec("UPDATE stocks SET name='%s',quantity=%d,min_quantity=%d WHERE id=%d;",
-                 item->name, item->quantity, item->min_quantity, id))
+    sqlite3_stmt *stmt =
+        db_query("UPDATE stocks SET name=?,quantity=?,min_quantity=? WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_text(stmt, 1, item->name, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 2, item->quantity);
+    sqlite3_bind_int(stmt, 3, item->min_quantity);
+    sqlite3_bind_int(stmt, 4, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     stock_items[idx] = *item;
     ESP_LOGI(TAG, "Mise a jour de l'article %d", id);
@@ -77,7 +95,13 @@ bool stocks_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    if (!db_exec("DELETE FROM stocks WHERE id=%d;", id))
+    sqlite3_stmt *stmt = db_query("DELETE FROM stocks WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     for (int i = idx; i < stock_count - 1; ++i) {
         stock_items[i] = stock_items[i + 1];

--- a/components/terrariums/terrariums.c
+++ b/components/terrariums/terrariums.c
@@ -54,9 +54,20 @@ bool terrariums_add(const Terrarium *t)
 {
     if (terrarium_count >= TERRARIUMS_MAX || !t)
         return false;
-    if (!db_exec("INSERT INTO terrariums(id,elevage_id,name,capacity,inventory,notes) "
-                 "VALUES(%d,%d,'%s',%d,'%s','%s');",
-                 t->id, t->elevage_id, t->name, t->capacity, t->inventory, t->notes))
+    sqlite3_stmt *stmt =
+        db_query("INSERT INTO terrariums(id,elevage_id,name,capacity,inventory,notes) "
+                 "VALUES(?,?,?,?,?,?);");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, t->id);
+    sqlite3_bind_int(stmt, 2, t->elevage_id);
+    sqlite3_bind_text(stmt, 3, t->name, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 4, t->capacity);
+    sqlite3_bind_text(stmt, 5, t->inventory, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 6, t->notes, -1, SQLITE_TRANSIENT);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     terrariums[terrarium_count] = *t;
     terrarium_count++;
@@ -86,8 +97,19 @@ bool terrariums_update(int id, const Terrarium *t)
     int idx = find_index(id);
     if (idx < 0 || !t)
         return false;
-    if (!db_exec("UPDATE terrariums SET elevage_id=%d,name='%s',capacity=%d,inventory='%s',notes='%s' WHERE id=%d;",
-                 t->elevage_id, t->name, t->capacity, t->inventory, t->notes, id))
+    sqlite3_stmt *stmt = db_query(
+        "UPDATE terrariums SET elevage_id=?,name=?,capacity=?,inventory=?,notes=? WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, t->elevage_id);
+    sqlite3_bind_text(stmt, 2, t->name, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 3, t->capacity);
+    sqlite3_bind_text(stmt, 4, t->inventory, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 5, t->notes, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 6, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     terrariums[idx] = *t;
     ESP_LOGI(TAG, "Mise a jour du terrarium %d", id);
@@ -99,7 +121,13 @@ bool terrariums_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    if (!db_exec("DELETE FROM terrariums WHERE id=%d;", id))
+    sqlite3_stmt *stmt = db_query("DELETE FROM terrariums WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     for (int i = idx; i < terrarium_count - 1; ++i) {
         terrariums[i] = terrariums[i + 1];
@@ -113,7 +141,13 @@ void terrariums_log_transaction(const char *msg)
 {
     if (log_count >= LOGS_MAX || !msg)
         return;
-    db_exec("INSERT INTO terrarium_logs(message,terrarium_id) VALUES('%s',0);", msg);
+    sqlite3_stmt *stmt =
+        db_query("INSERT INTO terrarium_logs(message,terrarium_id) VALUES(?,0);");
+    if (!stmt)
+        return;
+    sqlite3_bind_text(stmt, 1, msg, -1, SQLITE_TRANSIENT);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
     strncpy(logs[log_count], msg, sizeof(logs[0]) - 1);
     logs[log_count][sizeof(logs[0]) - 1] = '\0';
     ESP_LOGI(TAG, "Log: %s", logs[log_count]);

--- a/components/transactions/transactions.c
+++ b/components/transactions/transactions.c
@@ -44,8 +44,17 @@ bool transactions_add(const Transaction *t)
     if (transaction_count >= TRANSACTIONS_MAX || !t)
         return false;
     const char *type = t->type == TRANSACTION_SALE ? "SALE" : "PURCHASE";
-    if (!db_exec("INSERT INTO transactions(id,stock_id,quantity,type) VALUES(%d,%d,%d,'%s');",
-                 t->id, t->stock_id, t->quantity, type))
+    sqlite3_stmt *stmt =
+        db_query("INSERT INTO transactions(id,stock_id,quantity,type) VALUES(?,?,?,?);");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, t->id);
+    sqlite3_bind_int(stmt, 2, t->stock_id);
+    sqlite3_bind_int(stmt, 3, t->quantity);
+    sqlite3_bind_text(stmt, 4, type, -1, SQLITE_TRANSIENT);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     transactions[transaction_count] = *t;
     transaction_count++;
@@ -67,8 +76,17 @@ bool transactions_update(int id, const Transaction *t)
     if (idx < 0 || !t)
         return false;
     const char *type = t->type == TRANSACTION_SALE ? "SALE" : "PURCHASE";
-    if (!db_exec("UPDATE transactions SET stock_id=%d,quantity=%d,type='%s' WHERE id=%d;",
-                 t->stock_id, t->quantity, type, id))
+    sqlite3_stmt *stmt = db_query(
+        "UPDATE transactions SET stock_id=?,quantity=?,type=? WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, t->stock_id);
+    sqlite3_bind_int(stmt, 2, t->quantity);
+    sqlite3_bind_text(stmt, 3, type, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 4, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     transactions[idx] = *t;
     ESP_LOGI(TAG, "Mise a jour de la transaction %d", id);
@@ -80,7 +98,13 @@ bool transactions_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    if (!db_exec("DELETE FROM transactions WHERE id=%d;", id))
+    sqlite3_stmt *stmt = db_query("DELETE FROM transactions WHERE id=?;");
+    if (!stmt)
+        return false;
+    sqlite3_bind_int(stmt, 1, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (!ok)
         return false;
     for (int i = idx; i < transaction_count - 1; ++i) {
         transactions[i] = transactions[i + 1];


### PR DESCRIPTION
## Summary
- use prepared statements with bound parameters in animals, stocks, terrariums and other modules
- avoid SQL injection issues when inserting or updating records

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686103dbe7d48323b4a6a2fa8968601a