### PR TITLE
Add I2C Kconfig options

### DIFF
--- a/components/drivers/CMakeLists.txt
+++ b/components/drivers/CMakeLists.txt
@@ -1,3 +1,7 @@
 idf_component_register(SRCS "drivers.c" "lighting.c" "co2.c"
                        INCLUDE_DIRS "."
                        REQUIRES driver esp_http_client mqtt)
+
+# Expose project configuration options
+set_property(TARGET ${COMPONENT_LIB} PROPERTY
+             KCONFIG_PROJBUILD ${CMAKE_CURRENT_LIST_DIR}/Kconfig.projbuild)

--- a/components/drivers/Kconfig.projbuild
+++ b/components/drivers/Kconfig.projbuild
@@ -34,6 +34,24 @@ config LIGHTING_MQTT_TOPIC
     help
         Topic used when publishing lighting state via MQTT.
 
+config LIGHTING_SDA_GPIO
+    int "GPIO for lighting driver SDA"
+    default 21
+    help
+        I2C SDA pin used by the lighting controller.
+
+config LIGHTING_SCL_GPIO
+    int "GPIO for lighting driver SCL"
+    default 22
+    help
+        I2C SCL pin used by the lighting controller.
+
+config LIGHTING_I2C_ADDR
+    hex "I2C address of lighting controller"
+    default 0x40
+    help
+        I2C address used to communicate with the lighting controller.
+
 config CO2_SDA_GPIO
     int "GPIO for CO2 sensor SDA"
     default 21


### PR DESCRIPTION
## Summary
- allow setting I2C pins and address for lighting controller
- expose drivers Kconfig options via CMake

## Testing
- `pytest -q` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_e_686105f967c083238aaae6be8a12302c