### PR TITLE
Add sqlite component dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Vous pouvez aussi copier manuellement les composants dans le dossier `components
 
 ## Compilation
 ```bash
+idf.py add-dependency "espressif/sqlite3"
 idf.py set-target esp32s3
 idf.py build
 ```

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,2 +1,2 @@
 dependencies:
-  espressif/sqlite3: "*"
+  espressif/sqlite3: "^3.45.1"


### PR DESCRIPTION
## Summary
- specify the `espressif/sqlite3` component version in `idf_component.yml`
- call `idf.py add-dependency` before `idf.py build` in README

## Testing
- `idf.py set-target esp32s3` *(fails: command not found)*
- `idf.py build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68611005d0a48323acf147ef37f65f13