### PR TITLE
Add I2C Kconfig options

### DIFF
--- a/components/drivers/CMakeLists.txt
+++ b/components/drivers/CMakeLists.txt
@@ -4,4 +4,6 @@ idf_component_register(SRCS "drivers.c" "lighting.c" "co2.c"
 
 # Expose project configuration options
 set_property(TARGET ${COMPONENT_LIB} PROPERTY
+             KCONFIG ${CMAKE_CURRENT_LIST_DIR}/Kconfig)
+set_property(TARGET ${COMPONENT_LIB} PROPERTY
              KCONFIG_PROJBUILD ${CMAKE_CURRENT_LIST_DIR}/Kconfig.projbuild)

--- a/components/drivers/Kconfig
+++ b/components/drivers/Kconfig
@@ -1,0 +1,23 @@
+config I2C_SDA_GPIO
+    int "GPIO for shared I2C SDA"
+    default 21
+    help
+        SDA pin for the common I2C bus used by sensors.
+
+config I2C_SCL_GPIO
+    int "GPIO for shared I2C SCL"
+    default 22
+    help
+        SCL pin for the common I2C bus used by sensors.
+
+config CO2_SDA_GPIO
+    int "GPIO for CO2 sensor SDA"
+    default 21
+
+config CO2_SCL_GPIO
+    int "GPIO for CO2 sensor SCL"
+    default 22
+
+config CO2_I2C_ADDR
+    hex "I2C address of CO2 sensor"
+    default 0x61

--- a/components/drivers/drivers.c
+++ b/components/drivers/drivers.c
@@ -10,8 +10,6 @@
 static const char *TAG = "drivers";
 
 #define I2C_PORT           I2C_NUM_0
-#define I2C_SDA_GPIO       21
-#define I2C_SCL_GPIO       22
 #define I2C_FREQ_HZ        100000
 
 #define SHT3X_ADDR         0x44
@@ -25,8 +23,8 @@ void drivers_init(void)
 
     i2c_config_t conf = {
         .mode = I2C_MODE_MASTER,
-        .sda_io_num = I2C_SDA_GPIO,
-        .scl_io_num = I2C_SCL_GPIO,
+        .sda_io_num = CONFIG_I2C_SDA_GPIO,
+        .scl_io_num = CONFIG_I2C_SCL_GPIO,
         .sda_pullup_en = GPIO_PULLUP_ENABLE,
         .scl_pullup_en = GPIO_PULLUP_ENABLE,
         .master.clk_speed = I2C_FREQ_HZ,


### PR DESCRIPTION
## Summary
- allow configuring I2C GPIO pins for sensors
- expose driver Kconfig options
- use CONFIG_I2C_* in drivers implementation

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611149def8832399890269f6bc8de0