### PR TITLE
Use bound queries and add quote tests

### DIFF
--- a/components/terrariums/terrariums.c
+++ b/components/terrariums/terrariums.c
@@ -33,9 +33,10 @@ void terrariums_init(int log_offset)
 
     // Chargement des logs existants avec pagination
     sqlite3_stmt *log_stmt = db_query(
-        "SELECT message FROM terrarium_logs ORDER BY id DESC LIMIT %d OFFSET %d;",
-        LOGS_MAX, log_offset);
+        "SELECT message FROM terrarium_logs ORDER BY id DESC LIMIT ? OFFSET ?;");
     if (log_stmt) {
+        sqlite3_bind_int(log_stmt, 1, LOGS_MAX);
+        sqlite3_bind_int(log_stmt, 2, log_offset);
         while (sqlite3_step(log_stmt) == SQLITE_ROW && log_count < LOGS_MAX) {
             const unsigned char *msg = sqlite3_column_text(log_stmt, 0);
             if (msg) {

--- a/tests/test_crud.c
+++ b/tests/test_crud.c
@@ -14,11 +14,11 @@ TEST_CASE("animals crud", "[animals]") {
   animals_init();
   Reptile r = {.id = 1,
                .elevage_id = 1,
-               .name = "Liz",
-               .species = "Lizard",
+               .name = "L'iz",
+               .species = "Lizard's",
                .sex = "F",
                .birth_date = "2021",
-               .health = "ok",
+               .health = "o'k",
                .breeding_cycle = "",
                .cdc_number = "",
                .aoe_number = "",
@@ -31,10 +31,12 @@ TEST_CASE("animals crud", "[animals]") {
   TEST_ASSERT_EQUAL_INT(1, animals_count());
   const Reptile *g = animals_get(1);
   TEST_ASSERT_NOT_NULL(g);
-  strcpy(r.health, "good");
+  TEST_ASSERT_EQUAL_STRING("L'iz", g->name);
+  TEST_ASSERT_EQUAL_STRING("Lizard's", g->species);
+  strcpy(r.health, "g'ood");
   TEST_ASSERT_TRUE(animals_update(1, &r));
   g = animals_get(1);
-  TEST_ASSERT_EQUAL_STRING("good", g->health);
+  TEST_ASSERT_EQUAL_STRING("g'ood", g->health);
   TEST_ASSERT_TRUE(animals_delete(1));
   TEST_ASSERT_EQUAL_INT(0, animals_count());
   db_close();
@@ -44,10 +46,11 @@ TEST_CASE("terrariums crud", "[terrariums]") {
   db_set_key("");
   TEST_ASSERT_TRUE(db_open_custom(":memory:"));
   terrariums_init(0);
-  Terrarium t = {.id = 1, .elevage_id = 1, .name = "T1", .capacity = 2};
+  Terrarium t = {.id = 1, .elevage_id = 1, .name = "T'1", .capacity = 2};
   TEST_ASSERT_TRUE(terrariums_add(&t));
   const Terrarium *gt = terrariums_get(1);
   TEST_ASSERT_NOT_NULL(gt);
+  TEST_ASSERT_EQUAL_STRING("T'1", gt->name);
   t.capacity = 3;
   TEST_ASSERT_TRUE(terrariums_update(1, &t));
   gt = terrariums_get(1);
@@ -61,10 +64,11 @@ TEST_CASE("stocks crud", "[stocks]") {
   db_set_key("");
   TEST_ASSERT_TRUE(db_open_custom(":memory:"));
   stocks_init();
-  StockItem s = {.id = 1, .name = "Food", .quantity = 5, .min_quantity = 1};
+  StockItem s = {.id = 1, .name = "Fo'o", .quantity = 5, .min_quantity = 1};
   TEST_ASSERT_TRUE(stocks_add(&s));
   const StockItem *gs = stocks_get(1);
   TEST_ASSERT_NOT_NULL(gs);
+  TEST_ASSERT_EQUAL_STRING("Fo'o", gs->name);
   s.quantity = 7;
   TEST_ASSERT_TRUE(stocks_update(1, &s));
   gs = stocks_get(1);
@@ -97,14 +101,15 @@ TEST_CASE("health records crud", "[health]") {
   TEST_ASSERT_TRUE(db_open_custom(":memory:"));
   health_init();
   HealthRecord hr = {
-      .id = 1, .animal_id = 1, .description = "check", .date = 0};
+      .id = 1, .animal_id = 1, .description = "che'ck", .date = 0};
   TEST_ASSERT_TRUE(health_add(&hr));
   const HealthRecord *gr = health_get(1);
   TEST_ASSERT_NOT_NULL(gr);
-  strcpy(hr.description, "done");
+  TEST_ASSERT_EQUAL_STRING("che'ck", gr->description);
+  strcpy(hr.description, "do'ne");
   TEST_ASSERT_TRUE(health_update(1, &hr));
   gr = health_get(1);
-  TEST_ASSERT_EQUAL_STRING("done", gr->description);
+  TEST_ASSERT_EQUAL_STRING("do'ne", gr->description);
   TEST_ASSERT_TRUE(health_delete(1));
   TEST_ASSERT_NULL(health_get(1));
   db_close();
@@ -115,14 +120,15 @@ TEST_CASE("breeding events crud", "[breeding]") {
   TEST_ASSERT_TRUE(db_open_custom(":memory:"));
   breeding_init();
   BreedingEvent ev = {
-      .id = 1, .animal_id = 1, .description = "pair", .date = 0};
+      .id = 1, .animal_id = 1, .description = "pa'ir", .date = 0};
   TEST_ASSERT_TRUE(breeding_add(&ev));
   const BreedingEvent *ge = breeding_get(1);
   TEST_ASSERT_NOT_NULL(ge);
-  strcpy(ev.description, "laid");
+  TEST_ASSERT_EQUAL_STRING("pa'ir", ge->description);
+  strcpy(ev.description, "la'id");
   TEST_ASSERT_TRUE(breeding_update(1, &ev));
   ge = breeding_get(1);
-  TEST_ASSERT_EQUAL_STRING("laid", ge->description);
+  TEST_ASSERT_EQUAL_STRING("la'id", ge->description);
   TEST_ASSERT_TRUE(breeding_delete(1));
   TEST_ASSERT_NULL(breeding_get(1));
   db_close();


### PR DESCRIPTION
## Summary
- use parameter binding when loading terrarium logs
- test CRUD operations with strings that contain single quotes

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861125b4834832393b090fe70204e1e