### PR TITLE
Add docs for backup credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ LizardComette est un exemple de projet ESP‑IDF permettant de gérer un élevag
 3. Inspirez‑vous de `docs/CONFIG_EXAMPLE.md` pour créer votre propre `sdkconfig` (Wi‑Fi, stockage, REST/MQTT, etc.).
 4. Placez vos fichiers de licences CITES et autres documents dans le répertoire approprié.
 5. Ajustez `partition_table.csv` si vous avez besoin d'une taille différente pour les partitions SPIFFS ou SD afin de stocker la base de données.
+6. Pour envoyer automatiquement les sauvegardes sur un serveur HTTP, renseignez
+   `CONFIG_STORAGE_TRANSFER_URL` dans `sdkconfig`. Si votre serveur exige une
+   authentification, complétez également `CONFIG_STORAGE_TRANSFER_USERNAME` et
+   `CONFIG_STORAGE_TRANSFER_PASSWORD`.
 
 ## Installation des composants tiers
 Certaines bibliothèques ne sont pas incluses dans ce dépôt et doivent être téléchargées via le registre d'Espressif. Utilisez `idf.py add-dependency` pour installer chaque composant indiqué dans `idf_component.yml`. Par exemple, le projet requiert le composant `sqlite3` :

--- a/docs/CONFIG_EXAMPLE.md
+++ b/docs/CONFIG_EXAMPLE.md
@@ -29,6 +29,8 @@ renseignez `CONFIG_STORAGE_TRANSFER_USERNAME` et
 laissées vides ou omises.
 Ces trois options sont définies dans `components/storage/Kconfig.projbuild` et
 contrôlent le transfert de fichiers via le Wi‑Fi.
+Lorsque ces paramètres sont renseignés, la commande `db_backup()` du firmware
+crée une sauvegarde chiffrée puis la transmet automatiquement à l'URL fournie.
 
 `CONFIG_LIGHTING_PWM_GPIO` indique le GPIO utilisé pour piloter l'éclairage.
 Les options `CONFIG_CO2_SDA_GPIO`, `CONFIG_CO2_SCL_GPIO` et


### PR DESCRIPTION
## Summary
- explain how to configure HTTP credentials for backup transfers in README
- clarify backup upload behavior in CONFIG_EXAMPLE

## Testing
- `idf.py --version` *(fails: command not found)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68611391a1148323b8e73abba621a3df