### PR TITLE
Configure sqlite3 dependency

### DIFF
--- a/components/db/CMakeLists.txt
+++ b/components/db/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(SRCS "db.c"
                        INCLUDE_DIRS "."
-                       REQUIRES sqlite3)
+                       PRIV_REQUIRES sqlite3)
 
 # Expose project configuration options
 set_property(TARGET ${COMPONENT_LIB} PROPERTY

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,2 +1,2 @@
 dependencies:
-  espressif/sqlite3: "^3.45.1"
+  espressif/sqlite3: "~3.42"


### PR DESCRIPTION
## Summary
- pin sqlite3 component to version `~3.42`
- link sqlite3 privately in the db component

## Testing
- `idf.py add-dependency espressif/sqlite3` *(fails: command not found)*
- `idf.py set-target esp32s3` *(fails: command not found)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611629ba948323801923eda983152c