### PR TITLE
Add SQLite dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ idf.py add-dependency "espressif/sqlite3"
 Vous pouvez aussi copier manuellement les composants dans le dossier `components/`.
 
 ## Compilation
+Avant la première compilation, installez la dépendance puis lancez la
+construction du projet&nbsp;:
 ```bash
 idf.py add-dependency "espressif/sqlite3"
 idf.py set-target esp32s3

--- a/components/db/CMakeLists.txt
+++ b/components/db/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(SRCS "db.c"
                        INCLUDE_DIRS "."
-                       PRIV_REQUIRES sqlite3)
+                       REQUIRES sqlite3)
 
 # Expose project configuration options
 set_property(TARGET ${COMPONENT_LIB} PROPERTY


### PR DESCRIPTION
## Summary
- mention installing sqlite3 before building
- require sqlite3 component in database CMake

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611b8da1688323b37579d86b0738f5