### PR TITLE
Add lighting I2C Kconfig

### DIFF
--- a/components/drivers/Kconfig
+++ b/components/drivers/Kconfig
@@ -21,3 +21,15 @@ config CO2_SCL_GPIO
 config CO2_I2C_ADDR
     hex "I2C address of CO2 sensor"
     default 0x61
+
+config LIGHTING_SDA_GPIO
+    int "GPIO for lighting driver SDA"
+    default 21
+
+config LIGHTING_SCL_GPIO
+    int "GPIO for lighting driver SCL"
+    default 22
+
+config LIGHTING_I2C_ADDR
+    hex "I2C address of lighting controller"
+    default 0x40


### PR DESCRIPTION
## Summary
- expose lighting I2C pins via Kconfig

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611dc4826083238639b95e1235db03