### PR TITLE
Refactor CRUD functions to use prepared statements

### DIFF
--- a/components/animals/animals.c
+++ b/components/animals/animals.c
@@ -55,12 +55,10 @@ void animals_init(void) {
 bool animals_add(const Reptile *r) {
   if (animal_count >= ANIMALS_MAX || !r)
     return false;
-  sqlite3_stmt *stmt =
-      db_query("INSERT INTO "
-               "animals(id,elevage_id,name,species,sex,birth_date,health,"
-               "breeding_cycle,cdc_number,aoe_number,ifap_id,quota_limit,quota_"
-               "used,cerfa_valid_until,cites_valid_until) "
-               "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);");
+  sqlite3_stmt *stmt = db_prepare(
+      "INSERT INTO animals(id,elevage_id,name,species,sex,birth_date,health,"
+      "breeding_cycle,cdc_number,aoe_number,ifap_id,quota_limit,quota_used,"
+      "cerfa_valid_until,cites_valid_until) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);");
   if (!stmt)
     return false;
   sqlite3_bind_int(stmt, 1, r->id);
@@ -78,9 +76,7 @@ bool animals_add(const Reptile *r) {
   sqlite3_bind_int(stmt, 13, r->quota_used);
   sqlite3_bind_int(stmt, 14, r->cerfa_valid_until);
   sqlite3_bind_int(stmt, 15, r->cites_valid_until);
-  bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-  sqlite3_finalize(stmt);
-  if (!ok)
+  if (!db_step_finalize(stmt))
     return false;
   animals[animal_count] = *r;
   animal_count++;
@@ -107,11 +103,10 @@ bool animals_update(int id, const Reptile *r) {
   int idx = find_index(id);
   if (idx < 0 || !r)
     return false;
-  sqlite3_stmt *stmt =
-      db_query("UPDATE animals SET elevage_id=?,name=?,species=?,sex=?,"
-               "birth_date=?,health=?,breeding_cycle=?,cdc_number=?,aoe_number=?,"
-               "ifap_id=?,quota_limit=?,quota_used=?,cerfa_valid_until=?,cites_"
-               "valid_until=? WHERE id=?;");
+  sqlite3_stmt *stmt = db_prepare(
+      "UPDATE animals SET elevage_id=?,name=?,species=?,sex=?,birth_date=?,health=?,"
+      "breeding_cycle=?,cdc_number=?,aoe_number=?,ifap_id=?,quota_limit=?,quota_used=?,"
+      "cerfa_valid_until=?,cites_valid_until=? WHERE id=?;");
   if (!stmt)
     return false;
   sqlite3_bind_int(stmt, 1, r->elevage_id);
@@ -129,9 +124,7 @@ bool animals_update(int id, const Reptile *r) {
   sqlite3_bind_int(stmt, 13, r->cerfa_valid_until);
   sqlite3_bind_int(stmt, 14, r->cites_valid_until);
   sqlite3_bind_int(stmt, 15, id);
-  bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-  sqlite3_finalize(stmt);
-  if (!ok)
+  if (!db_step_finalize(stmt))
     return false;
   animals[idx] = *r;
   ESP_LOGI(TAG, "Mise a jour du reptile %d", id);
@@ -142,14 +135,11 @@ bool animals_delete(int id) {
   int idx = find_index(id);
   if (idx < 0)
     return false;
-  sqlite3_stmt *stmt =
-      db_query("DELETE FROM animals WHERE id=?;");
+  sqlite3_stmt *stmt = db_prepare("DELETE FROM animals WHERE id=?;");
   if (!stmt)
     return false;
   sqlite3_bind_int(stmt, 1, id);
-  bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-  sqlite3_finalize(stmt);
-  if (!ok)
+  if (!db_step_finalize(stmt))
     return false;
   for (int i = idx; i < animal_count - 1; ++i) {
     animals[i] = animals[i + 1];

--- a/components/animals/breeding.c
+++ b/components/animals/breeding.c
@@ -41,7 +41,7 @@ bool breeding_add(const BreedingEvent *ev)
 {
     if (event_count >= BREEDING_MAX || !ev)
         return false;
-    sqlite3_stmt *stmt = db_query(
+    sqlite3_stmt *stmt = db_prepare(
         "INSERT INTO breeding_events(id,animal_id,description,date) VALUES(?,?,?,?);");
     if (!stmt)
         return false;
@@ -49,9 +49,7 @@ bool breeding_add(const BreedingEvent *ev)
     sqlite3_bind_int(stmt, 2, ev->animal_id);
     sqlite3_bind_text(stmt, 3, ev->description, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 4, ev->date);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     events[event_count] = *ev;
     event_count++;
@@ -72,7 +70,7 @@ bool breeding_update(int id, const BreedingEvent *ev)
     int idx = find_index(id);
     if (idx < 0 || !ev)
         return false;
-    sqlite3_stmt *stmt = db_query(
+    sqlite3_stmt *stmt = db_prepare(
         "UPDATE breeding_events SET animal_id=?,description=?,date=? WHERE id=?;");
     if (!stmt)
         return false;
@@ -80,9 +78,7 @@ bool breeding_update(int id, const BreedingEvent *ev)
     sqlite3_bind_text(stmt, 2, ev->description, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 3, ev->date);
     sqlite3_bind_int(stmt, 4, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     events[idx] = *ev;
     events[idx].id = id;
@@ -95,13 +91,11 @@ bool breeding_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    sqlite3_stmt *stmt = db_query("DELETE FROM breeding_events WHERE id=?;");
+    sqlite3_stmt *stmt = db_prepare("DELETE FROM breeding_events WHERE id=?;");
     if (!stmt)
         return false;
     sqlite3_bind_int(stmt, 1, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     for (int i = idx; i < event_count - 1; ++i)
         events[i] = events[i + 1];

--- a/components/animals/health.c
+++ b/components/animals/health.c
@@ -41,7 +41,7 @@ bool health_add(const HealthRecord *rec)
 {
     if (record_count >= HEALTH_MAX || !rec)
         return false;
-    sqlite3_stmt *stmt = db_query(
+    sqlite3_stmt *stmt = db_prepare(
         "INSERT INTO health_records(id,animal_id,description,date) VALUES(?,?,?,?);");
     if (!stmt)
         return false;
@@ -49,9 +49,7 @@ bool health_add(const HealthRecord *rec)
     sqlite3_bind_int(stmt, 2, rec->animal_id);
     sqlite3_bind_text(stmt, 3, rec->description, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 4, rec->date);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     records[record_count] = *rec;
     record_count++;
@@ -72,7 +70,7 @@ bool health_update(int id, const HealthRecord *rec)
     int idx = find_index(id);
     if (idx < 0 || !rec)
         return false;
-    sqlite3_stmt *stmt = db_query(
+    sqlite3_stmt *stmt = db_prepare(
         "UPDATE health_records SET animal_id=?,description=?,date=? WHERE id=?;");
     if (!stmt)
         return false;
@@ -80,9 +78,7 @@ bool health_update(int id, const HealthRecord *rec)
     sqlite3_bind_text(stmt, 2, rec->description, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 3, rec->date);
     sqlite3_bind_int(stmt, 4, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     records[idx] = *rec;
     records[idx].id = id;
@@ -95,13 +91,11 @@ bool health_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    sqlite3_stmt *stmt = db_query("DELETE FROM health_records WHERE id=?;");
+    sqlite3_stmt *stmt = db_prepare("DELETE FROM health_records WHERE id=?;");
     if (!stmt)
         return false;
     sqlite3_bind_int(stmt, 1, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     for (int i = idx; i < record_count - 1; ++i)
         records[i] = records[i + 1];

--- a/components/auth/auth.c
+++ b/components/auth/auth.c
@@ -112,15 +112,13 @@ bool auth_add_user(const char *username, const char *password, user_role_t role)
     char hex[65];
     hash_to_hex(users[user_count].hash, hex);
     sqlite3_stmt *stmt =
-        db_query("INSERT INTO users(username,hash,role) VALUES(?,?,?);");
+        db_prepare("INSERT INTO users(username,hash,role) VALUES(?,?,?);");
     if (!stmt)
         return false;
     sqlite3_bind_text(stmt, 1, users[user_count].username, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 2, hex, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 3, role);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
 
     user_count++;
@@ -155,14 +153,12 @@ bool auth_link_elevage(const char *username, int elevage_id)
             if (users[i].elevage_count >= AUTH_MAX_ELEVAGES_PER_USER)
                 return false;
             sqlite3_stmt *stmt =
-                db_query("INSERT INTO user_elevages(username,elevage_id) VALUES(?,?);");
+                db_prepare("INSERT INTO user_elevages(username,elevage_id) VALUES(?,?);");
             if (!stmt)
                 return false;
             sqlite3_bind_text(stmt, 1, username, -1, SQLITE_TRANSIENT);
             sqlite3_bind_int(stmt, 2, elevage_id);
-            bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-            sqlite3_finalize(stmt);
-            if (!ok)
+            if (!db_step_finalize(stmt))
                 return false;
             users[i].elevages[users[i].elevage_count++] = elevage_id;
             return true;

--- a/components/db/db.c
+++ b/components/db/db.c
@@ -233,6 +233,25 @@ sqlite3_stmt *db_query(const char *format, ...) {
   return stmt;
 }
 
+sqlite3_stmt *db_prepare(const char *sql) {
+  sqlite3_stmt *stmt = NULL;
+  if (sqlite3_prepare_v2(db_handle, sql, -1, &stmt, NULL) != SQLITE_OK) {
+    ESP_LOGE(TAG, "SQL prepare error: %s", sqlite3_errmsg(db_handle));
+    return NULL;
+  }
+  return stmt;
+}
+
+bool db_step_finalize(sqlite3_stmt *stmt) {
+  if (!stmt)
+    return false;
+  bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+  if (!ok)
+    ESP_LOGE(TAG, "SQL step error: %s", sqlite3_errmsg(db_handle));
+  sqlite3_finalize(stmt);
+  return ok;
+}
+
 bool db_open_custom(const char *path) {
   if (!open_db(path))
     return false;

--- a/components/db/db.h
+++ b/components/db/db.h
@@ -46,6 +46,17 @@ bool db_exec(const char *format, ...);
 sqlite3_stmt *db_query(const char *format, ...);
 
 /**
+ * \brief Prépare une requête SQL sans arguments de format.
+ */
+sqlite3_stmt *db_prepare(const char *sql);
+
+/**
+ * \brief Exécute puis finalise une requête préparée.
+ * \return true si l'exécution s'est terminée sans erreur.
+ */
+bool db_step_finalize(sqlite3_stmt *stmt);
+
+/**
  * \brief Définit la clé SQLCipher à utiliser pour chiffrer la base.
  * \param key Chaîne de caractères UTF-8.
  * \return true si la clé a été enregistrée.

--- a/components/elevages/elevages.c
+++ b/components/elevages/elevages.c
@@ -42,15 +42,13 @@ bool elevages_add(const Elevage *e)
     if (elevage_count >= ELEVAGES_MAX || !e)
         return false;
     sqlite3_stmt *stmt =
-        db_query("INSERT INTO elevages(id,name,description) VALUES(?,?,?);");
+        db_prepare("INSERT INTO elevages(id,name,description) VALUES(?,?,?);");
     if (!stmt)
         return false;
     sqlite3_bind_int(stmt, 1, e->id);
     sqlite3_bind_text(stmt, 2, e->name, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 3, e->description, -1, SQLITE_TRANSIENT);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     elevages[elevage_count] = *e;
     elevage_count++;
@@ -72,15 +70,13 @@ bool elevages_update(int id, const Elevage *e)
     if (idx < 0 || !e)
         return false;
     sqlite3_stmt *stmt =
-        db_query("UPDATE elevages SET name=?,description=? WHERE id=?;");
+        db_prepare("UPDATE elevages SET name=?,description=? WHERE id=?;");
     if (!stmt)
         return false;
     sqlite3_bind_text(stmt, 1, e->name, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 2, e->description, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 3, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     elevages[idx] = *e;
     ESP_LOGI(TAG, "Mise a jour de l'elevage %d", id);
@@ -92,13 +88,11 @@ bool elevages_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    sqlite3_stmt *stmt = db_query("DELETE FROM elevages WHERE id=?;");
+    sqlite3_stmt *stmt = db_prepare("DELETE FROM elevages WHERE id=?;");
     if (!stmt)
         return false;
     sqlite3_bind_int(stmt, 1, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     for (int i = idx; i < elevage_count - 1; ++i) {
         elevages[i] = elevages[i + 1];

--- a/components/legal_numbers/legal_numbers.c
+++ b/components/legal_numbers/legal_numbers.c
@@ -49,7 +49,7 @@ bool legal_numbers_add(const LegalNumber *n)
 {
     if (number_count >= LEGAL_NUMBERS_MAX || !n)
         return false;
-    sqlite3_stmt *stmt = db_query(
+    sqlite3_stmt *stmt = db_prepare(
         "INSERT INTO cdc_aoe_numbers(id,username,elevage_id,type,number) VALUES(?,?,?,?,?);");
     if (!stmt)
         return false;
@@ -58,9 +58,7 @@ bool legal_numbers_add(const LegalNumber *n)
     sqlite3_bind_int(stmt, 3, n->elevage_id);
     sqlite3_bind_text(stmt, 4, n->type, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 5, n->number, -1, SQLITE_TRANSIENT);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     numbers[number_count] = *n;
     number_count++;
@@ -82,7 +80,7 @@ bool legal_numbers_update(int id, const LegalNumber *n)
     if (idx < 0 || !n)
         return false;
     sqlite3_stmt *stmt =
-        db_query("UPDATE cdc_aoe_numbers SET username=?,elevage_id=?,type=?,number=? WHERE id=?;");
+        db_prepare("UPDATE cdc_aoe_numbers SET username=?,elevage_id=?,type=?,number=? WHERE id=?;");
     if (!stmt)
         return false;
     sqlite3_bind_text(stmt, 1, n->username, -1, SQLITE_TRANSIENT);
@@ -90,9 +88,7 @@ bool legal_numbers_update(int id, const LegalNumber *n)
     sqlite3_bind_text(stmt, 3, n->type, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 4, n->number, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 5, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     numbers[idx] = *n;
     ESP_LOGI(TAG, "Mise a jour numero %d", id);
@@ -104,13 +100,11 @@ bool legal_numbers_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    sqlite3_stmt *stmt = db_query("DELETE FROM cdc_aoe_numbers WHERE id=?;");
+    sqlite3_stmt *stmt = db_prepare("DELETE FROM cdc_aoe_numbers WHERE id=?;");
     if (!stmt)
         return false;
     sqlite3_bind_int(stmt, 1, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     for (int i = idx; i < number_count - 1; ++i)
         numbers[i] = numbers[i + 1];

--- a/components/stocks/stocks.c
+++ b/components/stocks/stocks.c
@@ -43,16 +43,14 @@ bool stocks_add(const StockItem *item)
     if (stock_count >= STOCKS_MAX || !item)
         return false;
     sqlite3_stmt *stmt =
-        db_query("INSERT INTO stocks(id,name,quantity,min_quantity) VALUES(?,?,?,?);");
+        db_prepare("INSERT INTO stocks(id,name,quantity,min_quantity) VALUES(?,?,?,?);");
     if (!stmt)
         return false;
     sqlite3_bind_int(stmt, 1, item->id);
     sqlite3_bind_text(stmt, 2, item->name, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 3, item->quantity);
     sqlite3_bind_int(stmt, 4, item->min_quantity);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     stock_items[stock_count] = *item;
     stock_count++;
@@ -74,16 +72,14 @@ bool stocks_update(int id, const StockItem *item)
     if (idx < 0 || !item)
         return false;
     sqlite3_stmt *stmt =
-        db_query("UPDATE stocks SET name=?,quantity=?,min_quantity=? WHERE id=?;");
+        db_prepare("UPDATE stocks SET name=?,quantity=?,min_quantity=? WHERE id=?;");
     if (!stmt)
         return false;
     sqlite3_bind_text(stmt, 1, item->name, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 2, item->quantity);
     sqlite3_bind_int(stmt, 3, item->min_quantity);
     sqlite3_bind_int(stmt, 4, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     stock_items[idx] = *item;
     ESP_LOGI(TAG, "Mise a jour de l'article %d", id);
@@ -95,13 +91,11 @@ bool stocks_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    sqlite3_stmt *stmt = db_query("DELETE FROM stocks WHERE id=?;");
+    sqlite3_stmt *stmt = db_prepare("DELETE FROM stocks WHERE id=?;");
     if (!stmt)
         return false;
     sqlite3_bind_int(stmt, 1, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     for (int i = idx; i < stock_count - 1; ++i) {
         stock_items[i] = stock_items[i + 1];

--- a/components/terrariums/terrariums.c
+++ b/components/terrariums/terrariums.c
@@ -56,8 +56,7 @@ bool terrariums_add(const Terrarium *t)
     if (terrarium_count >= TERRARIUMS_MAX || !t)
         return false;
     sqlite3_stmt *stmt =
-        db_query("INSERT INTO terrariums(id,elevage_id,name,capacity,inventory,notes) "
-                 "VALUES(?,?,?,?,?,?);");
+        db_prepare("INSERT INTO terrariums(id,elevage_id,name,capacity,inventory,notes) VALUES(?,?,?,?,?,?);");
     if (!stmt)
         return false;
     sqlite3_bind_int(stmt, 1, t->id);
@@ -66,9 +65,7 @@ bool terrariums_add(const Terrarium *t)
     sqlite3_bind_int(stmt, 4, t->capacity);
     sqlite3_bind_text(stmt, 5, t->inventory, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 6, t->notes, -1, SQLITE_TRANSIENT);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     terrariums[terrarium_count] = *t;
     terrarium_count++;
@@ -98,7 +95,7 @@ bool terrariums_update(int id, const Terrarium *t)
     int idx = find_index(id);
     if (idx < 0 || !t)
         return false;
-    sqlite3_stmt *stmt = db_query(
+    sqlite3_stmt *stmt = db_prepare(
         "UPDATE terrariums SET elevage_id=?,name=?,capacity=?,inventory=?,notes=? WHERE id=?;");
     if (!stmt)
         return false;
@@ -108,9 +105,7 @@ bool terrariums_update(int id, const Terrarium *t)
     sqlite3_bind_text(stmt, 4, t->inventory, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 5, t->notes, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 6, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     terrariums[idx] = *t;
     ESP_LOGI(TAG, "Mise a jour du terrarium %d", id);
@@ -122,13 +117,11 @@ bool terrariums_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    sqlite3_stmt *stmt = db_query("DELETE FROM terrariums WHERE id=?;");
+    sqlite3_stmt *stmt = db_prepare("DELETE FROM terrariums WHERE id=?;");
     if (!stmt)
         return false;
     sqlite3_bind_int(stmt, 1, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     for (int i = idx; i < terrarium_count - 1; ++i) {
         terrariums[i] = terrariums[i + 1];
@@ -143,7 +136,7 @@ void terrariums_log_transaction(const char *msg)
     if (log_count >= LOGS_MAX || !msg)
         return;
     sqlite3_stmt *stmt =
-        db_query("INSERT INTO terrarium_logs(message,terrarium_id) VALUES(?,0);");
+        db_prepare("INSERT INTO terrarium_logs(message,terrarium_id) VALUES(?,0);");
     if (!stmt)
         return;
     sqlite3_bind_text(stmt, 1, msg, -1, SQLITE_TRANSIENT);

--- a/components/transactions/transactions.c
+++ b/components/transactions/transactions.c
@@ -45,16 +45,14 @@ bool transactions_add(const Transaction *t)
         return false;
     const char *type = t->type == TRANSACTION_SALE ? "SALE" : "PURCHASE";
     sqlite3_stmt *stmt =
-        db_query("INSERT INTO transactions(id,stock_id,quantity,type) VALUES(?,?,?,?);");
+        db_prepare("INSERT INTO transactions(id,stock_id,quantity,type) VALUES(?,?,?,?);");
     if (!stmt)
         return false;
     sqlite3_bind_int(stmt, 1, t->id);
     sqlite3_bind_int(stmt, 2, t->stock_id);
     sqlite3_bind_int(stmt, 3, t->quantity);
     sqlite3_bind_text(stmt, 4, type, -1, SQLITE_TRANSIENT);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     transactions[transaction_count] = *t;
     transaction_count++;
@@ -76,7 +74,7 @@ bool transactions_update(int id, const Transaction *t)
     if (idx < 0 || !t)
         return false;
     const char *type = t->type == TRANSACTION_SALE ? "SALE" : "PURCHASE";
-    sqlite3_stmt *stmt = db_query(
+    sqlite3_stmt *stmt = db_prepare(
         "UPDATE transactions SET stock_id=?,quantity=?,type=? WHERE id=?;");
     if (!stmt)
         return false;
@@ -84,9 +82,7 @@ bool transactions_update(int id, const Transaction *t)
     sqlite3_bind_int(stmt, 2, t->quantity);
     sqlite3_bind_text(stmt, 3, type, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 4, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     transactions[idx] = *t;
     ESP_LOGI(TAG, "Mise a jour de la transaction %d", id);
@@ -98,13 +94,11 @@ bool transactions_delete(int id)
     int idx = find_index(id);
     if (idx < 0)
         return false;
-    sqlite3_stmt *stmt = db_query("DELETE FROM transactions WHERE id=?;");
+    sqlite3_stmt *stmt = db_prepare("DELETE FROM transactions WHERE id=?;");
     if (!stmt)
         return false;
     sqlite3_bind_int(stmt, 1, id);
-    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
-    sqlite3_finalize(stmt);
-    if (!ok)
+    if (!db_step_finalize(stmt))
         return false;
     for (int i = idx; i < transaction_count - 1; ++i) {
         transactions[i] = transactions[i + 1];


### PR DESCRIPTION
## Summary
- add `db_prepare` and `db_step_finalize` helpers
- refactor CRUD modules to use the new helpers

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68612120bd588323a597a859f95da45f