### PR TITLE
Add menu for driver pin configuration

### DIFF
--- a/components/drivers/Kconfig
+++ b/components/drivers/Kconfig
@@ -1,3 +1,5 @@
+menu "Driver pin configuration"
+
 config I2C_SDA_GPIO
     int "GPIO for shared I2C SDA"
     default 21
@@ -13,10 +15,14 @@ config I2C_SCL_GPIO
 config CO2_SDA_GPIO
     int "GPIO for CO2 sensor SDA"
     default 21
+    help
+        SDA pin connected to the CO2 sensor.
 
 config CO2_SCL_GPIO
     int "GPIO for CO2 sensor SCL"
     default 22
+    help
+        SCL pin connected to the CO2 sensor.
 
 config CO2_I2C_ADDR
     hex "I2C address of CO2 sensor"
@@ -33,3 +39,5 @@ config LIGHTING_SCL_GPIO
 config LIGHTING_I2C_ADDR
     hex "I2C address of lighting controller"
     default 0x40
+
+endmenu


### PR DESCRIPTION
## Summary
- expose I2C pin options in a dedicated Kconfig menu
- keep Kconfig referenced from CMakeLists so pins can be changed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68612288cb588323821f1c5dbace587b