### PR TITLE
Fix db_init reopen

### DIFF
--- a/components/db/db.c
+++ b/components/db/db.c
@@ -280,7 +280,7 @@ void db_init(void) {
     }
   }
 
-  if (!open_db("/spiffs/lizard.db"))
+  if (!db_handle && !open_db("/spiffs/lizard.db"))
     return;
 
   create_tables();


### PR DESCRIPTION
## Summary
- avoid reopening the default database if it's already open

## Testing
- `idf.py build` *(fails: command not found)*
- `idf.py unity_test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686124c2a28483239d13435f98e26c5b