### PR TITLE
Add sqlite3 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ LizardComette est un exemple de projet ESP‑IDF permettant de gérer un élevag
    `CONFIG_STORAGE_TRANSFER_PASSWORD`.
 
 ## Installation des composants tiers
-Certaines bibliothèques ne sont pas incluses dans ce dépôt et doivent être téléchargées via le registre d'Espressif. Utilisez `idf.py add-dependency` pour installer chaque composant indiqué dans `idf_component.yml`. Par exemple, le projet requiert le composant `sqlite3` :
+Certaines bibliothèques ne sont pas incluses dans ce dépôt et doivent être téléchargées via le registre d'Espressif, en utilisant le gestionnaire de composants ESP‑IDF (component manager). Utilisez `idf.py add-dependency` pour installer chaque composant indiqué dans `idf_component.yml`. Par exemple, le projet requiert le composant `sqlite3` :
 
 ```bash
 idf.py add-dependency "espressif/sqlite3"

--- a/components/db/CMakeLists.txt
+++ b/components/db/CMakeLists.txt
@@ -1,6 +1,8 @@
-idf_component_register(SRCS "db.c"
-                       INCLUDE_DIRS "."
-                       REQUIRES sqlite3)
+idf_component_register(
+    SRCS "db.c"
+    INCLUDE_DIRS "."
+    REQUIRES sqlite3
+)
 
 # Expose project configuration options
 set_property(TARGET ${COMPONENT_LIB} PROPERTY

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,2 +1,2 @@
 dependencies:
-  espressif/sqlite3: "^3.42"
+  espressif/sqlite3: "*"


### PR DESCRIPTION
## Summary
- reference ESP-IDF component manager in docs
- update SQLite manifest requirements
- list sqlite3 as required component in db component

## Testing
- `python3 -m idf_component_manager manifest add-dependency "espressif/sqlite3" -p .` *(fails: connection error)*
- `idf.py build` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68612794709483238549ad6017c329b5