### PR TITLE
Add SQLite3 dep for DB component

### DIFF
--- a/components/db/idf_component.yml
+++ b/components/db/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  espressif/sqlite3: "*"


### PR DESCRIPTION
## Summary
- ensure the database component declares the SQLite3 dependency

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file)*
- `idf.py add-dependency "espressif/sqlite3=*"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68612eeeb8b48323a1c5ee12cfabc196