### PR TITLE
Add invoice generation on sale

### DIFF
--- a/components/transactions/CMakeLists.txt
+++ b/components/transactions/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "transactions.c"
                        INCLUDE_DIRS "."
-                       REQUIRES db sqlite3)
+                       REQUIRES db sqlite3 animals legal)

--- a/components/transactions/transactions.c
+++ b/components/transactions/transactions.c
@@ -1,6 +1,8 @@
 #include "transactions.h"
 #include "esp_log.h"
 #include "db.h"
+#include "animals.h"
+#include "legal.h"
 #include <sqlite3.h>
 #include <string.h>
 
@@ -57,6 +59,15 @@ bool transactions_add(const Transaction *t)
     transactions[transaction_count] = *t;
     transaction_count++;
     ESP_LOGI(TAG, "Ajout de la transaction %d", t->id);
+
+    if (t->type == TRANSACTION_SALE) {
+        const Reptile *r = animals_get(t->stock_id);
+        if (r) {
+            char path[32];
+            snprintf(path, sizeof(path), "invoice_%d.pdf", t->id);
+            legal_generate_invoice(path, r);
+        }
+    }
     return true;
 }
 

--- a/tests/test_legal.c
+++ b/tests/test_legal.c
@@ -3,6 +3,7 @@
 #include "legal_numbers.h"
 #include "db.h"
 #include "animals.h"
+#include "transactions.h"
 #include <sys/stat.h>
 #include <unistd.h>
 #include <time.h>
@@ -75,4 +76,34 @@ TEST_CASE("quota edge cases","[legal]")
     TEST_ASSERT_FALSE(legal_quota_remaining(&r));
     r.quota_used = -1;
     TEST_ASSERT_FALSE(legal_quota_remaining(&r));
+}
+
+TEST_CASE("invoice generated on sale","[transactions]")
+{
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    animals_init();
+    transactions_init();
+    Reptile r = {
+        .id = 1,
+        .elevage_id = 0,
+        .name = "Liz",
+        .species = "Lizard",
+        .sex = "F",
+        .birth_date = "2021",
+        .cdc_number = "",
+        .aoe_number = "",
+        .ifap_id = "",
+        .quota_limit = 0,
+        .quota_used = 0,
+        .cerfa_valid_until = 0,
+        .cites_valid_until = 0
+    };
+    TEST_ASSERT_TRUE(animals_add(&r));
+    Transaction t = { .id = 1, .stock_id = 1, .quantity = 1, .type = TRANSACTION_SALE };
+    TEST_ASSERT_TRUE(transactions_add(&t));
+    struct stat st;
+    TEST_ASSERT_EQUAL_INT(0, stat("invoice_1.pdf", &st));
+    unlink("invoice_1.pdf");
+    db_close();
 }


### PR DESCRIPTION
## Summary
- trigger PDF invoice when adding sale transaction
- require animals/ legal components for transactions
- test that sale transaction writes invoice

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686136e5e990832396db14dd34e5ad5d