### PR TITLE
Add setup tutorial and overlay customisation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,29 @@ Le projet a besoin du composant `sqlite3` fourni par l'ESP‑IDF. Celui‑ci est
 déclaré dans `idf_component.yml` sous le nom `espressif/sqlite3` et sera
 téléchargé automatiquement. Exécutez `idf.py create-component-manifest` ou `idf.py add-dependency "espressif/sqlite3^3"` pour générer `dependencies.lock` et installer la dépendance, ou placez le composant dans le répertoire `components/`.
 
+## Mise en route
+Ce petit tutoriel résume les étapes nécessaires lors de la première
+compilation et du flashage&nbsp;:
+
+1. Préparez l'environnement ESP‑IDF et ouvrez un terminal dans ce dépôt.
+2. Récupérez les dépendances déclarées dans `idf_component.yml`&nbsp;:
+   ```bash
+   idf.py add-dependency "espressif/sqlite3^3"
+   ```
+3. Sélectionnez la cible puis construisez le projet&nbsp;:
+   ```bash
+   idf.py set-target esp32s3
+   idf.py build
+   ```
+4. Branchez votre carte et flashez le firmware (remplacez le port
+   par celui de votre système)&nbsp;:
+   ```bash
+   idf.py -p /dev/ttyUSB0 flash monitor
+   ```
+5. Téléchargez les formulaires CERFA et CITES mentionnés dans
+   `docs/LEGAL_TEMPLATES.md` puis copiez-les dans le dossier `forms/`
+   en conservant les noms fournis.
+
 ## Tests
 L'ensemble des tests unitaires écrits avec Unity est regroupé dans le
 répertoire [`tests/`](tests/). Après avoir configuré l'ESP‑IDF, compilez le

--- a/docs/LEGAL_TEMPLATES.md
+++ b/docs/LEGAL_TEMPLATES.md
@@ -22,3 +22,13 @@ uniquement de tester la génération de documents. Pour adapter les superpositio
 à votre version des formulaires, modifiez les chaînes définies dans
 `components/legal/legal_templates.c` en ajustant le texte et les positions
 si nécessaire.
+
+## Personnalisation des superpositions
+
+Chaque constante déclarée dans `legal_templates.c` contient le texte qui sera
+ajouté en fin de PDF lors de la génération. Vous pouvez les modifier pour
+changer les intitulés ou la mise en page. Si vous devez positionner les
+champs de manière précise, insérez des commandes PDF (par exemple
+`X Y Td (contenu) Tj`) dans ces chaînes afin de placer les informations aux
+coordonnées souhaitées. Après toute modification, recompilez puis flashez le
+firmware pour vérifier le résultat sur vos formulaires officiels.


### PR DESCRIPTION
## Summary
- add a first-time setup tutorial explaining build, flash and PDF import
- document how to customise legal overlays

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686139e22f848323ab4ec10c09efb3eb