### PR TITLE
Specify sqlite3 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ idf.py add-dependency "espressif/sqlite3^3"
 ```
 
 Ceci télécharge le composant *SQLite3* et crée le fichier `dependencies.lock` nécessaire.
+N'oubliez pas d'ajouter ce fichier au contrôle de version afin d'éviter de
+télécharger à nouveau les dépendances lors des prochaines compilations.
 
 ## Utilisation
 Une fois flashé sur votre ESP32, le firmware démarre l'interface graphique en français ou en anglais selon la configuration. Les modules s'initialisent automatiquement puis le planificateur vérifie les tâches à venir. Consultez `docs/UI_USAGE.md` pour le détail des écrans et `docs/NOTICE.md` pour les avertissements légaux.

--- a/components/db/idf_component.yml
+++ b/components/db/idf_component.yml
@@ -1,2 +1,2 @@
 dependencies:
-  espressif/sqlite3: "*"
+  espressif/sqlite3: "^3"


### PR DESCRIPTION
## Summary
- lock sqlite3 major version in `components/db`
- advise committing dependencies.lock in build steps

## Testing
- `compote manifest add-dependency espressif/sqlite3^3 -p components/db --registry-url https://components.espressif.com` *(fails: Cannot establish a connection to the component registry)*

------
https://chatgpt.com/codex/tasks/task_e_68619ebc621883238d932d576082292e