### PR TITLE
Add exec_simple prototype

### DIFF
--- a/components/db/db.c
+++ b/components/db/db.c
@@ -27,6 +27,8 @@ static bool open_db(const char *path) {
   return true;
 }
 
+static void exec_simple(const char *sql);
+
 static void create_tables(void) {
   exec_simple("CREATE TABLE IF NOT EXISTS elevages("
               "


### PR DESCRIPTION
## Summary
- declare `exec_simple` before `create_tables` to avoid implicit declaration warnings

## Testing
- `ctest` *(fails: No test configuration file found)*
- `cmake .` *(fails: could not find requested file project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6861a0bac5c083238ca5db3b01d3842c