### PR TITLE
Add PDF export on sale transactions

### DIFF
--- a/components/transactions/CMakeLists.txt
+++ b/components/transactions/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "transactions.c"
                        INCLUDE_DIRS "."
-                       REQUIRES db sqlite3 animals legal)
+                       REQUIRES db sqlite3 animals legal storage)

--- a/components/transactions/transactions.c
+++ b/components/transactions/transactions.c
@@ -3,6 +3,7 @@
 #include "db.h"
 #include "animals.h"
 #include "legal.h"
+#include "storage.h"
 #include <sqlite3.h>
 #include <string.h>
 
@@ -62,11 +63,8 @@ bool transactions_add(const Transaction *t)
 
     if (t->type == TRANSACTION_SALE) {
         const Reptile *r = animals_get(t->stock_id);
-        if (r) {
-            char path[32];
-            snprintf(path, sizeof(path), "invoice_%d.pdf", t->id);
-            legal_generate_invoice(path, r);
-        }
+        if (r)
+            storage_export_pdf(".", r);
     }
     return true;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "test_auth.c" "test_db.c" "test_legal.c" "test_crud.c" \
                        "test_scheduler.c" "test_ui.c"
                        INCLUDE_DIRS ".."
-                      REQUIRES db sqlite3 auth legal legal_numbers animals terrariums stocks transactions scheduler unity)
+                     REQUIRES db sqlite3 auth legal legal_numbers animals terrariums stocks transactions scheduler storage unity)

--- a/tests/test_legal.c
+++ b/tests/test_legal.c
@@ -78,7 +78,7 @@ TEST_CASE("quota edge cases","[legal]")
     TEST_ASSERT_FALSE(legal_quota_remaining(&r));
 }
 
-TEST_CASE("invoice generated on sale","[transactions]")
+TEST_CASE("pdfs generated on sale","[transactions]")
 {
     db_set_key("");
     TEST_ASSERT_TRUE(db_open_custom(":memory:"));
@@ -103,7 +103,9 @@ TEST_CASE("invoice generated on sale","[transactions]")
     Transaction t = { .id = 1, .stock_id = 1, .quantity = 1, .type = TRANSACTION_SALE };
     TEST_ASSERT_TRUE(transactions_add(&t));
     struct stat st;
-    TEST_ASSERT_EQUAL_INT(0, stat("invoice_1.pdf", &st));
-    unlink("invoice_1.pdf");
+    TEST_ASSERT_EQUAL_INT(0, stat("invoice.pdf", &st));
+    TEST_ASSERT_EQUAL_INT(0, stat("cerfa.pdf", &st));
+    unlink("invoice.pdf");
+    unlink("cerfa.pdf");
     db_close();
 }


### PR DESCRIPTION
## Summary
- trigger PDF generation via `storage_export_pdf` when recording a sale
- expect PDF files in unit test after a sale
- link transactions and tests components with the storage component

## Testing
- `idf.py build` *(fails: command not found)*
- `idf.py unity_test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a3c7f4cc832396302b4211229039