### PR TITLE
Validate reptile legal numbers

### DIFF
--- a/components/animals/animals.c
+++ b/components/animals/animals.c
@@ -1,6 +1,8 @@
 #include "animals.h"
 #include "db.h"
 #include "esp_log.h"
+#include "legal_numbers.h"
+#include "ui.h"
 #include <sqlite3.h>
 #include <string.h>
 
@@ -55,6 +57,16 @@ void animals_init(void) {
 bool animals_add(const Reptile *r) {
   if (animal_count >= ANIMALS_MAX || !r)
     return false;
+  if (!legal_numbers_is_cdc_valid(r->cdc_number, NULL, r->elevage_id)) {
+    ESP_LOGW(TAG, "CDC invalide pour %s", r->name);
+    ui_notify("CDC invalide");
+    return false;
+  }
+  if (!legal_numbers_is_aoe_valid(r->aoe_number, NULL, r->elevage_id)) {
+    ESP_LOGW(TAG, "AOE invalide pour %s", r->name);
+    ui_notify("AOE invalide");
+    return false;
+  }
   sqlite3_stmt *stmt = db_prepare(
       "INSERT INTO animals(id,elevage_id,name,species,sex,birth_date,health,"
       "breeding_cycle,cdc_number,aoe_number,ifap_id,quota_limit,quota_used,"
@@ -103,6 +115,16 @@ bool animals_update(int id, const Reptile *r) {
   int idx = find_index(id);
   if (idx < 0 || !r)
     return false;
+  if (!legal_numbers_is_cdc_valid(r->cdc_number, NULL, r->elevage_id)) {
+    ESP_LOGW(TAG, "CDC invalide pour %s", r->name);
+    ui_notify("CDC invalide");
+    return false;
+  }
+  if (!legal_numbers_is_aoe_valid(r->aoe_number, NULL, r->elevage_id)) {
+    ESP_LOGW(TAG, "AOE invalide pour %s", r->name);
+    ui_notify("AOE invalide");
+    return false;
+  }
   sqlite3_stmt *stmt = db_prepare(
       "UPDATE animals SET elevage_id=?,name=?,species=?,sex=?,birth_date=?,health=?,"
       "breeding_cycle=?,cdc_number=?,aoe_number=?,ifap_id=?,quota_limit=?,quota_used=?,"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "test_auth.c" "test_db.c" "test_legal.c" "test_crud.c" \
-                       "test_scheduler.c" "test_ui.c"
+                       "test_scheduler.c" "test_ui.c" "test_animals_validation.c"
                        INCLUDE_DIRS ".."
                      REQUIRES db sqlite3 auth legal legal_numbers animals terrariums stocks transactions scheduler storage unity)

--- a/tests/test_animals_validation.c
+++ b/tests/test_animals_validation.c
@@ -1,0 +1,57 @@
+#include "unity.h"
+#include "db.h"
+#include "animals.h"
+#include "legal_numbers.h"
+
+static char last_msg[64];
+
+void ui_notify(const char *msg) {
+    if (!msg) return;
+    strncpy(last_msg, msg, sizeof(last_msg)-1);
+    last_msg[sizeof(last_msg)-1] = '\0';
+}
+
+static void reset_msg(void) {
+    last_msg[0] = '\0';
+}
+
+TEST_CASE("reject invalid cdc on add","[animals]")
+{
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    legal_numbers_init();
+    LegalNumber cdc={.id=1,.username="",.elevage_id=0,.type="CDC",.number="GOODCDC"};
+    LegalNumber aoe={.id=2,.username="",.elevage_id=0,.type="AOE",.number="GOODAOE"};
+    TEST_ASSERT_TRUE(legal_numbers_add(&cdc));
+    TEST_ASSERT_TRUE(legal_numbers_add(&aoe));
+    animals_init();
+    Reptile r={.id=1,.elevage_id=0,.name="Liz",.species="Lizard",.sex="F",.birth_date="2020",.cdc_number="BAD",.aoe_number="GOODAOE",.ifap_id="",.quota_limit=0,.quota_used=0,.cerfa_valid_until=0,.cites_valid_until=0};
+    reset_msg();
+    TEST_ASSERT_FALSE(animals_add(&r));
+    TEST_ASSERT_EQUAL_INT(0, animals_count());
+    TEST_ASSERT_EQUAL_STRING("CDC invalide", last_msg);
+    db_close();
+}
+
+TEST_CASE("reject invalid aoe on update","[animals]")
+{
+    db_set_key("");
+    TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    legal_numbers_init();
+    LegalNumber cdc={.id=1,.username="",.elevage_id=0,.type="CDC",.number="GOODCDC"};
+    LegalNumber aoe={.id=2,.username="",.elevage_id=0,.type="AOE",.number="GOODAOE"};
+    TEST_ASSERT_TRUE(legal_numbers_add(&cdc));
+    TEST_ASSERT_TRUE(legal_numbers_add(&aoe));
+    animals_init();
+    Reptile r={.id=1,.elevage_id=0,.name="Liz",.species="Lizard",.sex="F",.birth_date="2020",.cdc_number="GOODCDC",.aoe_number="GOODAOE",.ifap_id="",.quota_limit=0,.quota_used=0,.cerfa_valid_until=0,.cites_valid_until=0};
+    TEST_ASSERT_TRUE(animals_add(&r));
+    r.aoe_number[0]='\0';
+    strcpy(r.aoe_number,"BAD");
+    reset_msg();
+    TEST_ASSERT_FALSE(animals_update(1,&r));
+    const Reptile *g = animals_get(1);
+    TEST_ASSERT_NOT_NULL(g);
+    TEST_ASSERT_EQUAL_STRING("GOODAOE", g->aoe_number);
+    TEST_ASSERT_EQUAL_STRING("AOE invalide", last_msg);
+    db_close();
+}

--- a/tests/test_crud.c
+++ b/tests/test_crud.c
@@ -11,6 +11,11 @@
 TEST_CASE("animals crud", "[animals]") {
   db_set_key("");
   TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+  legal_numbers_init();
+  LegalNumber n1 = {.id = 1, .username = "", .elevage_id = 1, .type = "CDC", .number = "CDC1"};
+  LegalNumber n2 = {.id = 2, .username = "", .elevage_id = 1, .type = "AOE", .number = "AOE1"};
+  TEST_ASSERT_TRUE(legal_numbers_add(&n1));
+  TEST_ASSERT_TRUE(legal_numbers_add(&n2));
   animals_init();
   Reptile r = {.id = 1,
                .elevage_id = 1,
@@ -20,8 +25,8 @@ TEST_CASE("animals crud", "[animals]") {
                .birth_date = "2021",
                .health = "o'k",
                .breeding_cycle = "",
-               .cdc_number = "",
-               .aoe_number = "",
+               .cdc_number = "CDC1",
+               .aoe_number = "AOE1",
                .ifap_id = "",
                .quota_limit = 0,
                .quota_used = 0,

--- a/tests/test_legal.c
+++ b/tests/test_legal.c
@@ -82,6 +82,11 @@ TEST_CASE("pdfs generated on sale","[transactions]")
 {
     db_set_key("");
     TEST_ASSERT_TRUE(db_open_custom(":memory:"));
+    legal_numbers_init();
+    LegalNumber ln1 = {.id=1, .username="", .elevage_id=0, .type="CDC", .number="CDC123"};
+    LegalNumber ln2 = {.id=2, .username="", .elevage_id=0, .type="AOE", .number="AOE456"};
+    TEST_ASSERT_TRUE(legal_numbers_add(&ln1));
+    TEST_ASSERT_TRUE(legal_numbers_add(&ln2));
     animals_init();
     transactions_init();
     Reptile r = {
@@ -91,8 +96,8 @@ TEST_CASE("pdfs generated on sale","[transactions]")
         .species = "Lizard",
         .sex = "F",
         .birth_date = "2021",
-        .cdc_number = "",
-        .aoe_number = "",
+        .cdc_number = "CDC123",
+        .aoe_number = "AOE456",
         .ifap_id = "",
         .quota_limit = 0,
         .quota_used = 0,


### PR DESCRIPTION
## Summary
- ensure animals module checks CDC and AOE numbers using `cdc_aoe_numbers`
- notify UI when invalid numbers are provided
- update CRUD and legal tests to register valid numbers
- add new tests verifying rejection of invalid numbers

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a68f71e8832393277ef3c85b690d