### PR TITLE
Add reptile_manager crate

### DIFF
--- a/reptile_manager/Cargo.toml
+++ b/reptile_manager/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "reptile_manager"
+version = "0.1.0"
+edition = "2021"
+resolver = "2"
+
+[dependencies]
+esp-idf-sys = { version = "0.29", features = ["binstart"] }
+esp-idf-hal = "0.29"
+lvgl = { version = "0.8", features = ["embedded_graphics"] }
+anyhow = "1"
+log = "0.4"

--- a/reptile_manager/build.rs
+++ b/reptile_manager/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    esp_idf_sys::build();
+}

--- a/reptile_manager/src/main.rs
+++ b/reptile_manager/src/main.rs
@@ -1,0 +1,19 @@
+#![no_std]
+#![no_main]
+
+use esp_idf_hal::entry;
+
+#[entry]
+fn main() -> ! {
+    loop {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
## Summary
- create new ESP-IDF-based crate `reptile_manager`
- configure Cargo.toml with edition 2021 and resolver 2
- add required dependencies
- add build script for `esp-idf-sys`
- implement minimal `no_std`/`no_main` app with `esp-idf-hal` entry macro

## Testing
- `cargo check` *(fails: failed to select a version for lvgl)*

------
https://chatgpt.com/codex/tasks/task_e_686657f374cc832385bfcc2c97172c2b