### PR TITLE
Add module skeletons

### DIFF
--- a/reptile_manager/src/config/mod.rs
+++ b/reptile_manager/src/config/mod.rs
@@ -1,0 +1,3 @@
+//! Paramètres de configuration de l'application.
+
+pub mod settings;

--- a/reptile_manager/src/config/settings.rs
+++ b/reptile_manager/src/config/settings.rs
@@ -1,0 +1,6 @@
+//! Chargement et sauvegarde de la configuration.
+
+/// Charge la configuration depuis la mémoire.
+pub fn charger() {
+    // TODO: charger la configuration
+}

--- a/reptile_manager/src/domain/animals.rs
+++ b/reptile_manager/src/domain/animals.rs
@@ -1,0 +1,6 @@
+//! Gestion des données relatives aux animaux.
+
+/// Ajoute un nouvel animal.
+pub fn ajouter() {
+    // TODO: implémenter l'ajout d'un animal
+}

--- a/reptile_manager/src/domain/environment.rs
+++ b/reptile_manager/src/domain/environment.rs
@@ -1,0 +1,6 @@
+//! Conditions environnementales du terrarium.
+
+/// Met à jour les paramètres environnementaux.
+pub fn mettre_a_jour() {
+    // TODO: mettre à jour l'environnement
+}

--- a/reptile_manager/src/domain/feeding.rs
+++ b/reptile_manager/src/domain/feeding.rs
@@ -1,0 +1,6 @@
+//! Suivi de l'alimentation des animaux.
+
+/// Planifie un repas.
+pub fn planifier() {
+    // TODO: planifier un repas
+}

--- a/reptile_manager/src/domain/health.rs
+++ b/reptile_manager/src/domain/health.rs
@@ -1,0 +1,6 @@
+//! Suivi de la santé des animaux.
+
+/// Enregistre un contrôle de santé.
+pub fn enregistrer() {
+    // TODO: enregistrer les données de santé
+}

--- a/reptile_manager/src/domain/mod.rs
+++ b/reptile_manager/src/domain/mod.rs
@@ -1,0 +1,6 @@
+//! Logique métier du gestionnaire de reptiles.
+
+pub mod animals;
+pub mod environment;
+pub mod feeding;
+pub mod health;

--- a/reptile_manager/src/hardware/actuators.rs
+++ b/reptile_manager/src/hardware/actuators.rs
@@ -1,0 +1,6 @@
+//! Actionneurs contrôlés par le système.
+
+/// Active un actionneur spécifique.
+pub fn activer() {
+    // TODO: activer l'actionneur
+}

--- a/reptile_manager/src/hardware/display.rs
+++ b/reptile_manager/src/hardware/display.rs
@@ -1,0 +1,6 @@
+//! Gestion de l'affichage du système.
+
+/// Initialise l'affichage.
+pub fn init() {
+    // TODO: ajouter l'initialisation de l'écran
+}

--- a/reptile_manager/src/hardware/mod.rs
+++ b/reptile_manager/src/hardware/mod.rs
@@ -1,0 +1,6 @@
+//! Abstractions for all hardware peripherals.
+
+pub mod actuators;
+pub mod display;
+pub mod sensors;
+pub mod touch;

--- a/reptile_manager/src/hardware/sensors.rs
+++ b/reptile_manager/src/hardware/sensors.rs
@@ -1,0 +1,6 @@
+//! Capteurs utilisés par le système.
+
+/// Lit les données des capteurs.
+pub fn lire() {
+    // TODO: lire les capteurs
+}

--- a/reptile_manager/src/hardware/touch.rs
+++ b/reptile_manager/src/hardware/touch.rs
@@ -1,0 +1,6 @@
+//! Gestion du contrôleur tactile.
+
+/// Configure le périphérique tactile.
+pub fn configurer() {
+    // TODO: configurer le périphérique tactile
+}

--- a/reptile_manager/src/main.rs
+++ b/reptile_manager/src/main.rs
@@ -1,5 +1,13 @@
 #![no_std]
 #![no_main]
+mod config;
+mod domain;
+mod hardware;
+mod network;
+mod storage;
+mod tasks;
+mod ui;
+mod utils;
 
 use esp_idf_hal::entry;
 

--- a/reptile_manager/src/network/http.rs
+++ b/reptile_manager/src/network/http.rs
@@ -1,0 +1,6 @@
+//! Client HTTP léger.
+
+/// Envoie une requête HTTP.
+pub fn envoyer() {
+    // TODO: envoyer la requête
+}

--- a/reptile_manager/src/network/mod.rs
+++ b/reptile_manager/src/network/mod.rs
@@ -1,0 +1,5 @@
+//! Communication réseau.
+
+pub mod http;
+pub mod mqtt;
+pub mod wifi;

--- a/reptile_manager/src/network/mqtt.rs
+++ b/reptile_manager/src/network/mqtt.rs
@@ -1,0 +1,6 @@
+//! Support du protocole MQTT.
+
+/// Publie un message MQTT.
+pub fn publier() {
+    // TODO: publier un message
+}

--- a/reptile_manager/src/network/wifi.rs
+++ b/reptile_manager/src/network/wifi.rs
@@ -1,0 +1,6 @@
+//! Gestion du module Wi-Fi.
+
+/// Connecte l'appareil au réseau Wi-Fi.
+pub fn connecter() {
+    // TODO: implémenter la connexion Wi-Fi
+}

--- a/reptile_manager/src/storage/cache.rs
+++ b/reptile_manager/src/storage/cache.rs
@@ -1,0 +1,6 @@
+//! Mécanismes de cache pour des accès rapides.
+
+/// Vide le cache.
+pub fn vider() {
+    // TODO: vider le cache
+}

--- a/reptile_manager/src/storage/database.rs
+++ b/reptile_manager/src/storage/database.rs
@@ -1,0 +1,6 @@
+//! Accès à la base de données embarquée.
+
+/// Ouvre la connexion à la base de données.
+pub fn ouvrir() {
+    // TODO: ouvrir la connexion
+}

--- a/reptile_manager/src/storage/filesystem.rs
+++ b/reptile_manager/src/storage/filesystem.rs
@@ -1,0 +1,6 @@
+//! Accès au système de fichiers.
+
+/// Sauvegarde des données sur le système de fichiers.
+pub fn sauvegarder() {
+    // TODO: écrire les données sur le disque
+}

--- a/reptile_manager/src/storage/mod.rs
+++ b/reptile_manager/src/storage/mod.rs
@@ -1,0 +1,5 @@
+//! Gestion du stockage des données.
+
+pub mod cache;
+pub mod database;
+pub mod filesystem;

--- a/reptile_manager/src/tasks/jobs.rs
+++ b/reptile_manager/src/tasks/jobs.rs
@@ -1,0 +1,6 @@
+//! Ensemble de tâches prédéfinies.
+
+/// Exécute une tâche donnée.
+pub fn executer() {
+    // TODO: exécuter la tâche
+}

--- a/reptile_manager/src/tasks/mod.rs
+++ b/reptile_manager/src/tasks/mod.rs
@@ -1,0 +1,5 @@
+//! Gestionnaire de tâches de fond.
+
+pub mod jobs;
+pub mod scheduler;
+pub mod worker;

--- a/reptile_manager/src/tasks/scheduler.rs
+++ b/reptile_manager/src/tasks/scheduler.rs
@@ -1,0 +1,6 @@
+//! Planificateur de tâches périodiques.
+
+/// Lance le planificateur.
+pub fn lancer() {
+    // TODO: démarrer la planification
+}

--- a/reptile_manager/src/tasks/worker.rs
+++ b/reptile_manager/src/tasks/worker.rs
@@ -1,0 +1,6 @@
+//! Boucle principale des tâches asynchrones.
+
+/// Démarre le travailleur de tâches.
+pub fn demarrer() {
+    // TODO: lancer le travailleur
+}

--- a/reptile_manager/src/ui/mod.rs
+++ b/reptile_manager/src/ui/mod.rs
@@ -1,0 +1,6 @@
+//! Interface utilisateur graphique.
+
+pub mod navigation;
+pub mod screens;
+pub mod theme;
+pub mod widgets;

--- a/reptile_manager/src/ui/navigation.rs
+++ b/reptile_manager/src/ui/navigation.rs
@@ -1,0 +1,6 @@
+//! Navigation entre les différentes vues.
+
+/// Passe à l'écran suivant.
+pub fn suivant() {
+    // TODO: navigation vers l'écran suivant
+}

--- a/reptile_manager/src/ui/screens.rs
+++ b/reptile_manager/src/ui/screens.rs
@@ -1,0 +1,6 @@
+//! Gestion des écrans de l'interface.
+
+/// Affiche l'écran principal.
+pub fn afficher_principal() {
+    // TODO: implémenter l'affichage principal
+}

--- a/reptile_manager/src/ui/theme.rs
+++ b/reptile_manager/src/ui/theme.rs
@@ -1,0 +1,6 @@
+//! Gestion du thème de l'application.
+
+/// Applique le thème courant.
+pub fn appliquer() {
+    // TODO: appliquer le thème
+}

--- a/reptile_manager/src/ui/widgets.rs
+++ b/reptile_manager/src/ui/widgets.rs
@@ -1,0 +1,6 @@
+//! Composants graphiques réutilisables.
+
+/// Crée un bouton standard.
+pub fn creer_bouton() {
+    // TODO: créer un bouton
+}

--- a/reptile_manager/src/utils/conversions.rs
+++ b/reptile_manager/src/utils/conversions.rs
@@ -1,0 +1,7 @@
+//! Fonctions d'aide pour les conversions de données.
+
+/// Convertit des degrés Celsius en Fahrenheit.
+pub fn celsius_en_fahrenheit(c: f32) -> f32 {
+    // TODO: implémenter la conversion
+    c * 1.8 + 32.0
+}

--- a/reptile_manager/src/utils/logging.rs
+++ b/reptile_manager/src/utils/logging.rs
@@ -1,0 +1,6 @@
+//! Outils de journalisation.
+
+/// Initialise le système de logs.
+pub fn init() {
+    // TODO: initialiser le logging
+}

--- a/reptile_manager/src/utils/math.rs
+++ b/reptile_manager/src/utils/math.rs
@@ -1,0 +1,7 @@
+//! Fonctions mathématiques supplémentaires.
+
+/// Calcule la moyenne de deux nombres.
+pub fn moyenne(a: f32, b: f32) -> f32 {
+    // TODO: calculer la moyenne
+    (a + b) / 2.0
+}

--- a/reptile_manager/src/utils/mod.rs
+++ b/reptile_manager/src/utils/mod.rs
@@ -1,0 +1,5 @@
+//! Fonctions utilitaires diverses.
+
+pub mod conversions;
+pub mod logging;
+pub mod math;


### PR DESCRIPTION
## Summary
- set up configuration, hardware, UI, domain, storage, network, tasks, and utils modules
- stub out submodules with French documentation
- wire modules into `main.rs`

## Testing
- `cargo test --quiet` *(fails: failed to select a version for the requirement `lvgl = "^0.8"`)*

------
https://chatgpt.com/codex/tasks/task_e_6866599e38688323a3e7d942fbea9dcf