### PR TITLE
Add task spawning skeletons

### DIFF
--- a/reptile_manager/src/main.rs
+++ b/reptile_manager/src/main.rs
@@ -10,9 +10,14 @@ mod ui;
 mod utils;
 
 use esp_idf_hal::entry;
+use tasks::spawner::spawn_tasks;
 
 #[entry]
 fn main() -> ! {
+    // TODO: initialiser le matériel
+    // Lance les tâches système une fois le matériel prêt
+    spawn_tasks().expect("erreur lancement tâches");
+
     loop {}
 }
 

--- a/reptile_manager/src/tasks/mod.rs
+++ b/reptile_manager/src/tasks/mod.rs
@@ -3,3 +3,4 @@
 pub mod jobs;
 pub mod scheduler;
 pub mod worker;
+pub mod spawner;

--- a/reptile_manager/src/tasks/spawner.rs
+++ b/reptile_manager/src/tasks/spawner.rs
@@ -1,0 +1,47 @@
+//! Création des tâches système.
+
+use core::ffi::c_void;
+use esp_idf_hal::{delay::FreeRtos, task};
+use esp_idf_sys::{self as _, EspError};
+
+extern "C" fn ui_task(_ptr: *mut c_void) {
+    loop {
+        // Appel périodique de la boucle LVGL
+        unsafe { lvgl::sys::lv_timer_handler(); }
+        // TODO: ajuster la cadence en fonction de la charge
+        FreeRtos::delay_ms(5);
+    }
+}
+
+extern "C" fn sensor_task(_ptr: *mut c_void) {
+    loop {
+        // TODO: lire périodiquement les capteurs
+        FreeRtos::delay_ms(100);
+    }
+}
+
+extern "C" fn pid_task(_ptr: *mut c_void) {
+    loop {
+        // TODO: contrôler les actionneurs avec un PID
+        FreeRtos::delay_ms(50);
+    }
+}
+
+extern "C" fn network_task(_ptr: *mut c_void) {
+    loop {
+        // TODO: gérer le Wi-Fi et les appels API
+        FreeRtos::delay_ms(200);
+    }
+}
+
+/// Démarre toutes les tâches de fond du système.
+pub fn spawn_tasks() -> Result<(), EspError> {
+    unsafe {
+        // TODO: définir les tailles de pile et priorités correctes
+        task::create(ui_task,    esp_idf_sys::cstr!("ui"),      4096, core::ptr::null_mut(), 5, None)?;
+        task::create(sensor_task, esp_idf_sys::cstr!("sensors"), 4096, core::ptr::null_mut(), 5, None)?;
+        task::create(pid_task,    esp_idf_sys::cstr!("pid"),     4096, core::ptr::null_mut(), 5, None)?;
+        task::create(network_task, esp_idf_sys::cstr!("network"), 4096, core::ptr::null_mut(), 5, None)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- create `spawn_tasks` with basic task loops using `esp_idf_hal::task`
- expose the new spawner module
- call `spawn_tasks` from `main`

## Testing
- `cargo check` *(fails: failed to select a version for the requirement `lvgl = "^0.8"`)*

------
https://chatgpt.com/codex/tasks/task_e_68665cc3b97483238ed2655e3da5bcaf