### PR TITLE
Add network manager stubs and OTA notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # lizardcomette
+
+This project targets ESP32 devices. Upcoming versions will integrate over-the-air
+updates with `EspOta`. Firmware information will be saved in NVS so the
+bootloader can verify and roll back if needed. When encryption is enabled,
+Wi-Fi credentials and other secrets will be stored in the encrypted NVS
+partition.

--- a/reptile_manager/src/network/api.rs
+++ b/reptile_manager/src/network/api.rs
@@ -1,0 +1,25 @@
+//! Serveur HTTP exposant les routes de l'application et intégrant MQTT.
+
+/// Gère l'API haut niveau.
+pub struct ApiServer {
+    // TODO: stocker les gestionnaires HTTP/MQTT
+}
+
+impl ApiServer {
+    /// Crée une nouvelle instance d'[`ApiServer`].
+    pub fn new() -> Self {
+        Self {
+            // TODO: initialiser les gestionnaires
+        }
+    }
+
+    /// Lance le serveur HTTP et définit les routes.
+    pub fn start(&mut self) {
+        // TODO: définir les routes HTTP
+    }
+
+    /// Publie un message via MQTT.
+    pub fn publish_status(&self) {
+        // TODO: publier l'état via MQTT
+    }
+}

--- a/reptile_manager/src/network/mod.rs
+++ b/reptile_manager/src/network/mod.rs
@@ -3,3 +3,4 @@
 pub mod http;
 pub mod mqtt;
 pub mod wifi;
+pub mod api;

--- a/reptile_manager/src/network/wifi.rs
+++ b/reptile_manager/src/network/wifi.rs
@@ -1,6 +1,30 @@
 //! Gestion du module Wi-Fi.
 
-/// Connecte l'appareil au réseau Wi-Fi.
-pub fn connecter() {
-    // TODO: implémenter la connexion Wi-Fi
+/// Structure simplifiée gérant la connexion Wi-Fi.
+pub struct WifiManager {
+    // TODO: stocker le pilote Wi-Fi ou les paramètres nécessaires
+}
+
+impl WifiManager {
+    /// Crée un nouveau [`WifiManager`].
+    pub fn new() -> Self {
+        Self {
+            // TODO: initialiser les champs
+        }
+    }
+
+    /// Connecte l'appareil au réseau.
+    pub fn connect(&mut self) {
+        // TODO: implémenter la connexion Wi-Fi
+    }
+
+    /// Callback lorsque la connexion est établie.
+    pub fn on_connected(&mut self) {
+        // TODO: réagir à la connexion
+    }
+
+    /// Callback lorsque la connexion est perdue.
+    pub fn on_disconnected(&mut self) {
+        // TODO: réagir à la déconnexion
+    }
 }


### PR DESCRIPTION
## Summary
- implement `WifiManager` skeleton with connect callbacks
- stub `ApiServer` for HTTP and MQTT
- expose new module in network mod
- mention OTA updates using `EspOta` and encrypted NVS in README

## Testing
- `cargo check` *(fails: failed to select a version for lvgl)*

------
https://chatgpt.com/codex/tasks/task_e_68665ea15d548323bbe83e9d4c7ede30