### PR TITLE
Add RTC and error util modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,17 @@ updates with `EspOta`. Firmware information will be saved in NVS so the
 bootloader can verify and roll back if needed. When encryption is enabled,
 Wi-Fi credentials and other secrets will be stored in the encrypted NVS
 partition.
+
+## Utilities
+
+Utility modules live under `reptile_manager/src/utils`.
+
+- `errors.rs` re-exports [`anyhow::Error`](https://docs.rs/anyhow) and
+  `anyhow::Result` so you can simply `use crate::utils::errors::*;`.
+- `time.rs` provides the `Rtc` struct wrapping a PCF85063 I2C driver. It exposes
+  two helper methods:
+  - `now()` to read the current time from the RTC
+  - `set_time()` to update the clock
+
+These modules are publicly exported in `utils::` and can be used across the
+project with `use crate::utils::time::Rtc;` for example.

--- a/reptile_manager/src/utils/errors.rs
+++ b/reptile_manager/src/utils/errors.rs
@@ -1,0 +1,1 @@
+pub use anyhow::{Error, Result};

--- a/reptile_manager/src/utils/mod.rs
+++ b/reptile_manager/src/utils/mod.rs
@@ -1,5 +1,7 @@
 //! Fonctions utilitaires diverses.
 
 pub mod conversions;
+pub mod errors;
 pub mod logging;
 pub mod math;
+pub mod time;

--- a/reptile_manager/src/utils/time.rs
+++ b/reptile_manager/src/utils/time.rs
@@ -1,0 +1,22 @@
+//! Real time clock utilities using a PCF85063 I2C driver.
+
+use crate::utils::errors::Result;
+
+/// Simple wrapper around the PCF85063 RTC.
+pub struct Rtc {
+    // TODO: store I2C interface/driver once available
+}
+
+impl Rtc {
+    /// Returns the current timestamp from the RTC.
+    pub fn now(&self) -> Result<u64> {
+        // Placeholder implementation
+        Ok(0)
+    }
+
+    /// Sets the RTC to the provided timestamp.
+    pub fn set_time(&mut self, _timestamp: u64) -> Result<()> {
+        // Placeholder implementation
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add utility module for RTC with placeholder PCF85063 driver
- re-export `anyhow` errors
- expose new utilities in `utils` and document their usage

## Testing
- `cargo fmt`
- `cargo check` *(fails: failed to select a version for `lvgl`)*
- `cargo test` *(fails: failed to select a version for `lvgl`)*

------
https://chatgpt.com/codex/tasks/task_e_686661f26a1c8323bbf27c5eb35126b9