### PR TITLE
Add chrono and RTC driver dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,16 @@ Utility modules live under `reptile_manager/src/utils`.
 
 These modules are publicly exported in `utils::` and can be used across the
 project with `use crate::utils::time::Rtc;` for example.
+
+## Dependencies and features
+
+`reptile_manager` relies on a few external crates to run on ESP32 hardware:
+
+- [`pcf85063a`](https://crates.io/crates/pcf85063a) provides the RTC driver.
+- [`chrono`](https://crates.io/crates/chrono) handles timestamp conversions. In
+  embedded (`no_std`) environments the crate must be built with
+  `default-features = false` and the `alloc` feature enabled:
+
+```toml
+chrono = { version = "0.4", default-features = false, features = ["alloc"] }
+```

--- a/reptile_manager/Cargo.toml
+++ b/reptile_manager/Cargo.toml
@@ -11,6 +11,8 @@ lvgl = { version = "0.8", features = ["embedded_graphics"] }
 anyhow = "1"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
+pcf85063a = "0.1"
+chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 
 [lib]
 doctest = true


### PR DESCRIPTION
## Summary
- add `chrono` and `pcf85063a` dependencies
- document required features for using `chrono` in `no_std` environments

## Testing
- `cargo check` *(fails: failed to select a version for the requirement `lvgl = "^0.8"`)*

------
https://chatgpt.com/codex/tasks/task_e_68666c5e33348323a9564394a4dd1434