### PR TITLE
Ajout des drivers matériels

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ project with `use crate::utils::time::Rtc;` for example.
 ```toml
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 ```
+
+- [`xpt2046`](https://crates.io/crates/xpt2046) drives the SPI touch controller.
+- [`bme280`](https://crates.io/crates/bme280) provides environmental sensing over I2C.
+- [`onewire`](https://crates.io/crates/onewire) and [`ds18b20`](https://crates.io/crates/ds18b20) handle OneWire devices.

--- a/reptile_manager/Cargo.toml
+++ b/reptile_manager/Cargo.toml
@@ -13,6 +13,10 @@ log = "0.4"
 serde = { version = "1", features = ["derive"] }
 pcf85063a = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
+xpt2046 = "0.3"
+bme280 = "0.5"
+onewire = "0.4"
+ds18b20 = "0.1"
 
 [lib]
 doctest = true

--- a/reptile_manager/src/hardware/actuators.rs
+++ b/reptile_manager/src/hardware/actuators.rs
@@ -1,8 +1,22 @@
 //! Actionneurs contrôlés par le système.
 
-/// Active un actionneur spécifique.
+use ds18b20::Ds18b20;
+use esp_idf_hal::gpio::PinDriver;
+use esp_idf_hal::prelude::*;
+use onewire::OneWire;
+
+/// Initialise le bus OneWire et active un actionneur.
 pub fn activer() {
-    // TODO: activer l'actionneur
+    let peripherals = esp_idf_hal::peripherals::Peripherals::take().unwrap();
+
+    let pin = PinDriver::input_output(peripherals.pins.gpio4).unwrap();
+    let mut one = OneWire::new(pin).unwrap();
+
+    // Exemple : recherche d'un périphérique OneWire, ici un capteur DS18B20
+    if let Ok(Some(device)) = one.reset_search().next() {
+        let mut sensor = Ds18b20::new(device).unwrap();
+        let _ = sensor.start_temp_measurement(&mut one);
+    }
 }
 
 #[cfg(test)]

--- a/reptile_manager/src/hardware/sensors.rs
+++ b/reptile_manager/src/hardware/sensors.rs
@@ -1,8 +1,26 @@
 //! Capteurs utilisés par le système.
 
-/// Lit les données des capteurs.
-pub fn lire() {
-    // TODO: lire les capteurs
+use bme280::BME280;
+use esp_idf_hal::i2c::{self, I2c};
+use esp_idf_hal::prelude::*;
+
+/// Initialise le capteur BME280 sur le bus I2C puis lit une mesure.
+pub fn lire() -> bme280::Result<bme280::Measurements<I2c<'static>>> {
+    let peripherals = esp_idf_hal::peripherals::Peripherals::take().unwrap();
+
+    let i2c = i2c::Master::new(
+        peripherals.i2c0,
+        i2c::Pins {
+            sda: peripherals.pins.gpio21,
+            scl: peripherals.pins.gpio22,
+        },
+        i2c::config::Config::new().baudrate(Hertz(400_000)),
+    )
+    .unwrap();
+
+    let mut bme280 = BME280::new_primary(i2c);
+    bme280.init().ok();
+    bme280.measure()
 }
 
 #[cfg(test)]

--- a/reptile_manager/src/hardware/touch.rs
+++ b/reptile_manager/src/hardware/touch.rs
@@ -1,8 +1,40 @@
 //! Gestion du contrôleur tactile.
 
-/// Configure le périphérique tactile.
-pub fn configurer() {
-    // TODO: configurer le périphérique tactile
+use esp_idf_hal::prelude::*;
+use esp_idf_hal::spi::{self, Master};
+use xpt2046::{Orientation, Xpt2046};
+
+/// Configure le contrôleur tactile et retourne le driver [`Xpt2046`].
+pub fn configurer() -> Xpt2046<
+    Master<
+        spi::SPI3,
+        esp_idf_hal::gpio::Gpio25<esp_idf_hal::gpio::Output>,
+        esp_idf_hal::gpio::Gpio26<esp_idf_hal::gpio::Output>,
+        esp_idf_hal::gpio::Gpio27<esp_idf_hal::gpio::Input>,
+        esp_idf_hal::gpio::Gpio33<esp_idf_hal::gpio::Output>,
+    >,
+    esp_idf_hal::gpio::Gpio33<esp_idf_hal::gpio::Output>,
+    esp_idf_hal::gpio::Gpio32<esp_idf_hal::gpio::Input>,
+> {
+    // Récupère les périphériques pour configurer les broches SPI
+    let peripherals = esp_idf_hal::peripherals::Peripherals::take().unwrap();
+
+    let spi = Master::new(
+        peripherals.spi3,
+        spi::Pins {
+            sclk: peripherals.pins.gpio25,
+            sdo: peripherals.pins.gpio26,
+            sdi: Some(peripherals.pins.gpio27),
+            cs: Some(peripherals.pins.gpio33),
+        },
+        spi::config::Config::default(),
+    )
+    .unwrap();
+
+    let irq = peripherals.pins.gpio32;
+    let cs = peripherals.pins.gpio33;
+
+    Xpt2046::new(spi, cs, irq, Orientation::Portrait)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- configure SPI touch driver
- read BME280 sensor over I2C
- add simple OneWire actuator example
- list the new drivers in Cargo.toml and README

## Testing
- `cargo check` *(fails: failed to select a version for lvgl)*

------
https://chatgpt.com/codex/tasks/task_e_68666d6b113483238d3a17c1e917cdcf