### PR TITLE
Implémente thème, écrans et navigation

### DIFF
--- a/reptile_manager/src/ui/navigation.rs
+++ b/reptile_manager/src/ui/navigation.rs
@@ -1,8 +1,42 @@
 //! Navigation entre les différentes vues.
 
-/// Passe à l'écran suivant.
+use super::screens::{self, Screen};
+
+/// Gestionnaire de navigation circulaire entre plusieurs écrans.
+pub struct Navigator {
+    screens: [Screen; 5],
+    index: usize,
+}
+
+impl Navigator {
+    /// Crée une nouvelle instance contenant l'ensemble des écrans connus.
+    pub const fn new() -> Self {
+        Self {
+            screens: screens::tous(),
+            index: 0,
+        }
+    }
+
+    /// Retourne l'écran courant.
+    pub fn courant(&self) -> &Screen {
+        &self.screens[self.index]
+    }
+
+    /// Avance vers l'écran suivant en boucle.
+    pub fn suivant(&mut self) {
+        self.index = (self.index + 1) % self.screens.len();
+    }
+}
+
+/// Passe à l'écran suivant en utilisant un [`Navigator`] global.
 pub fn suivant() {
-    // TODO: navigation vers l'écran suivant
+    use core::cell::RefCell;
+
+    thread_local! {
+        static NAV: RefCell<Navigator> = RefCell::new(Navigator::new());
+    }
+
+    NAV.with(|nav| nav.borrow_mut().suivant());
 }
 
 #[cfg(test)]

--- a/reptile_manager/src/ui/screens.rs
+++ b/reptile_manager/src/ui/screens.rs
@@ -1,27 +1,73 @@
 //! Gestion des écrans de l'interface.
 
-/// Représente un écran générique.
-///
-/// # Examples
-///
-/// ```
-/// use reptile_manager::ui::screens::Screen;
-/// let screen = Screen::new("Accueil");
-/// ```
+/// Types d'écrans gérés par l'application.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScreenKind {
+    Accueil,
+    Capteurs,
+    Graphiques,
+    Reglages,
+    Apropos,
+}
+
+/// Représente un écran générique avec un nom et un type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Screen {
     name: &'static str,
+    kind: ScreenKind,
 }
 
 impl Screen {
     /// Crée un nouvel [`Screen`].
-    pub fn new(name: &'static str) -> Self {
-        Self { name }
+    pub const fn new(name: &'static str, kind: ScreenKind) -> Self {
+        Self { name, kind }
+    }
+
+    /// Retourne le nom de l'écran.
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Retourne le type d'écran.
+    pub const fn kind(&self) -> ScreenKind {
+        self.kind
     }
 }
 
-/// Affiche l'écran principal.
+/// Construit l'écran d'accueil.
+pub const fn accueil() -> Screen {
+    Screen::new("Accueil", ScreenKind::Accueil)
+}
+
+/// Construit l'écran listant les capteurs.
+pub const fn capteurs() -> Screen {
+    Screen::new("Capteurs", ScreenKind::Capteurs)
+}
+
+/// Construit l'écran affichant les graphiques.
+pub const fn graphiques() -> Screen {
+    Screen::new("Graphiques", ScreenKind::Graphiques)
+}
+
+/// Construit l'écran de réglages.
+pub const fn reglages() -> Screen {
+    Screen::new("Réglages", ScreenKind::Reglages)
+}
+
+/// Construit l'écran d'information sur l'application.
+pub const fn apropos() -> Screen {
+    Screen::new("À propos", ScreenKind::Apropos)
+}
+
+/// Retourne la liste de tous les écrans dans l'ordre de navigation.
+pub const fn tous() -> [Screen; 5] {
+    [accueil(), capteurs(), graphiques(), reglages(), apropos()]
+}
+
+/// Affiche l'écran principal. Dans ce squelette l'implémentation se limite à
+/// un journalisation via [`log`].
 pub fn afficher_principal() {
-    // TODO: implémenter l'affichage principal
+    log::info!("Affichage de l'écran: {}", accueil().name());
 }
 
 #[cfg(test)]

--- a/reptile_manager/src/ui/theme.rs
+++ b/reptile_manager/src/ui/theme.rs
@@ -1,8 +1,59 @@
 //! Gestion du thème de l'application.
 
-/// Applique le thème courant.
+use core::cell::Cell;
+
+/// Représente les couleurs et polices utilisées par l'interface.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Theme {
+    /// Couleur de fond principale sous forme RVB 0xRRGGBB.
+    pub background: u32,
+    /// Couleur de texte principale sous forme RVB 0xRRGGBB.
+    pub foreground: u32,
+    /// Police utilisée pour le texte courant.
+    pub font_small: &'static str,
+    /// Police utilisée pour les titres.
+    pub font_large: &'static str,
+}
+
+impl Theme {
+    /// Crée un nouveau thème avec les paramètres donnés.
+    pub const fn new(
+        background: u32,
+        foreground: u32,
+        font_small: &'static str,
+        font_large: &'static str,
+    ) -> Self {
+        Self {
+            background,
+            foreground,
+            font_small,
+            font_large,
+        }
+    }
+
+    /// Retourne un thème par défaut.
+    pub const fn default() -> Self {
+        Self::new(0x000000, 0xFFFFFF, "sans", "sans-bold")
+    }
+}
+
+/// Thème courant stocké dans une cellule globale.
+static CURRENT_THEME: Cell<Option<Theme>> = Cell::new(None);
+
+/// Applique le thème courant. S'il n'y a pas de thème défini, le thème par
+/// défaut est utilisé. L'application concrète dépend de LVGL et n'est pas
+/// implémentée ici.
 pub fn appliquer() {
-    // TODO: appliquer le thème
+    let theme = CURRENT_THEME.get().unwrap_or_else(|| {
+        let d = Theme::default();
+        CURRENT_THEME.set(Some(d));
+        d
+    });
+
+    // Dans un projet réel, on configurerait ici les styles LVGL à partir des
+    // couleurs et polices du thème. Les appels sont laissés de côté afin de
+    // conserver ce module indépendant du matériel.
+    let _ = theme;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add a `Theme` struct with default colors and fonts
- create five screens and helper constructors
- implement a circular navigation system

## Testing
- `cargo test --quiet` *(fails: failed to select a version for the requirement `lvgl = "^0.8"`)*

------
https://chatgpt.com/codex/tasks/task_e_68666f4081fc8323906b1e366c813a11