### PR TITLE
Add records module with JSON load/save

### DIFF
--- a/reptile_manager/src/domain/mod.rs
+++ b/reptile_manager/src/domain/mod.rs
@@ -4,6 +4,7 @@ pub mod animals;
 pub mod environment;
 pub mod feeding;
 pub mod health;
+pub mod records;
 
 #[cfg(test)]
 mod tests {
@@ -15,5 +16,6 @@ mod tests {
         environment::mettre_a_jour();
         feeding::planifier();
         health::enregistrer();
+        let _ = records::Record { id: 0, notes: String::new() };
     }
 }

--- a/reptile_manager/src/domain/records.rs
+++ b/reptile_manager/src/domain/records.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+/// Représente une entrée générique du registre.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct Record {
+    pub id: u32,
+    pub notes: String,
+}
+
+/// Sauvegarde la structure `Record` au format JSON sur le disque.
+pub fn sauvegarder(record: &Record, path: &str) -> Result<()> {
+    let contenu = serde_json::to_string(record)?;
+    std::fs::write(path, contenu)?;
+    Ok(())
+}
+
+/// Charge une structure `Record` depuis un fichier JSON.
+pub fn charger(path: &str) -> Result<Record> {
+    let contenu = std::fs::read_to_string(path)?;
+    let record = serde_json::from_str(&contenu)?;
+    Ok(record)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sauvegarde_et_chargement() {
+        let r = Record { id: 1, notes: "ok".into() };
+        let path = "/tmp/record.json";
+        sauvegarder(&r, path).unwrap();
+        let loaded = charger(path).unwrap();
+        assert_eq!(loaded, r);
+        std::fs::remove_file(path).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `records` module to `domain`
- export `records` from `domain::mod`
- implement JSON loading and saving using `serde_json`

## Testing
- `cargo test --quiet` *(fails: no matching package found for `LvgL`)*

------
https://chatgpt.com/codex/tasks/task_e_68668017ea088323b73de0bdcdd5389c